### PR TITLE
Implement alternative output types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+    - name: Test workflow (alt-output)
+      uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
+      with:
+        directory: .test
+        snakefile: workflow/Snakefile
+        args: "--configfile .test/configs/altoutput_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache"
     - name: Test workflow (transcripts)
       uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
       with:
@@ -86,3 +92,15 @@ jobs:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/configs/hisat2_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache"
+    - name: Clean up
+      uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
+      with:
+        directory: .test
+        snakefile: workflow/Snakefile
+        args: "--configfile .test/configs/transcript_nofastp.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --delete-all-output"
+    - name: Test workflow (no cB)
+      uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
+      with:
+        directory: .test
+        snakefile: workflow/Snakefile
+        args: "--configfile .test/configs/nocB_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --delete-all-output"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,3 +104,15 @@ jobs:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/configs/nocB_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache"
+    - name: Clean up again
+      uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
+      with:
+        directory: .test
+        snakefile: workflow/Snakefile
+        args: "--configfile .test/configs/transcript_nofastp.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --delete-all-output"
+    - name: Test workflow (lowRAM arrow)
+      uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
+      with:
+        directory: .test
+        snakefile: workflow/Snakefile
+        args: "--configfile .test/configs/lowram_arrow_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,4 +103,4 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/nocB_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --delete-all-output"
+        args: "--configfile .test/configs/nocB_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache"

--- a/.test/configs/altoutput_config.yaml
+++ b/.test/configs/altoutput_config.yaml
@@ -1,0 +1,303 @@
+####### GENERAL INFORMATION ABOUT THIS CONFIG #######
+#
+# This config file allows you to specify a number of important pieces of information that
+# the fastq2EZbakR pipeline will require to run. It also allows you to set optional parameters
+# for all tools that fastq2EZbakR makes use of.
+#
+# File paths can either be absolute (e.g., ~/path/to/file/or/directory) or relative
+# to the directory in which you are calling the pipeline from (e.g., data/fastq/WT_1 in the 
+# example samples entry means to look in the data directory present in the directory
+# where you called `snakemake` to run the pipeline).
+#
+####### PARAMETERS YOU NEED TO SET #######
+
+
+## Paths to data to process
+# path to directory containing fastq files if bam2bakr is False
+  # fastq files can be either gzipped or unzipped
+  # Each set of fastq files must be in a different directory
+# path to bam files if bam2bakr is True
+samples:
+    WT_1: data/bams/WT_replicate_1.bam
+    WT_2: data/bams/WT_replicate_2.bam
+    WT_ctl: data/bams/WT_nos4U.bam
+
+## example of what samples will look like for fastq input
+# samples:
+#   WT_1: data/fastq/WT_1
+#   WT_2: data/fastq/WT_2
+#   WT_ctl: data/fastq/WT_ctl
+#   KO_1: data/fastq/KO_1
+#   KO_2: data/fastq/KO_2
+#   KO_ctl: data/fastq/KO_ctl
+
+
+# -s4U control sample IDs
+control_samples: ['WT_ctl']
+
+# Paired end? 
+  # Set to True or False, no double quotes
+PE: True
+
+# Path to genome fasta file
+genome: data/genome/genome.fasta
+
+
+# Path to annotation gtf file
+annotation: data/annotation/genome.gtf
+
+
+# Which aligner to use? 
+  # Options are:
+    # 1) star
+    # 2) hisat2
+aligner: "hisat2"
+
+
+# Path to directory containing indices
+  # Indices will be built automatically if not present
+  # I would suggest naming this "aligner"_index, though any
+  # directory path name will do (avoid results/...; the 
+  # results/ directory is where the pipeline output will be created,
+  # so probably better to avoid specifying a path there that might
+  # clash with the names of one of the other automatically created
+  # directories). 
+indices: star_index
+
+
+# Strandedness
+  # set to "reverse", "yes", or "no"
+  # reverse means that read 2 represents 5' to 3' sequence of original RNA (read 1 thus represents its reverse complement)
+  # yes means that read 1 represents 5' to 3' sequence of original RNA
+  # no means unstranded
+  # Used by HTSeq (see https://htseq.readthedocs.io/en/master/htseqcount.html for details)
+strandedness: "reverse"
+
+
+# Augmentative analysis strategies
+  # Transcripts:
+    # Only compatible with STAR alignment.
+    # Final cB will have a column named "transcripts" which will indicate the set of transcripts that each read is 
+    # compatible with. This can be used in conjunction with bakR to perform transcript-isoform specific kinetic parameter
+    # estimates.
+  # FlatStacks:
+    # Flatten annotation with DEXSeq and have a column in the final cB correspond to assignment of reads to exonic
+    # bins. Useful to identify certain isoform-specific effects.
+  # RSEM+:
+    # Onloy compatible with STAR alignment.
+    # Estimate kinetic parameters for transcript isoforms by combining RSEM quantification with bakR's statistical model.
+strategies:
+    RSEMp: False
+    Transcripts: False
+
+
+# Features to quantify
+features:
+    genes: True
+    exons: True
+    transcripts: True
+    exonic_bins: True
+    junctions: False
+    eij: False
+    eej: False
+
+
+# Merge mutation counts and feature assignments in a RAM-efficient manner?
+  # Downside is that it's a bit slower
+lowRAM: False
+
+####### OPTIONAL PARAMETERS FOR EACH TOOL USED #######
+
+
+##### PARAMETERS MOST WORTH DOUBLE CHECKING #####
+
+# Adapters to pass to fastp 
+  # Not strictly necessary as fastp can autodetect. Autodetection is more accurate for paired-end data
+  # For paired-end data with widely used Illumina TruSeq adapters, this could be: 
+  # "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+fastp_adapters: ""
+
+
+# Path to flattened annotation 
+# Will be created if not already present
+# Only relevant if using FlatStacks
+flat_annotation: "data/annotation/flat_b2b.gtf"
+
+# Track site-specific mutational information
+mutpos: False
+
+# Normalize sequencing tracks?
+normalize: True
+
+
+
+# Types of mutations to make tracks for otherwise
+  # Comma separated string of mutation type
+  # Examples:
+    # "TC"
+      # count T-to-C mutations
+    # "TC,GA"
+      # counts T-to-C and G-to-A mutations
+mut_tracks: "TC"
+
+
+# Minimum base quality to call mutation
+minqual: 40
+
+
+# Add a full-gene "transcript" to annotation used for STAR + RSEM to quantify pre-mRNA.
+  # This is a nice way to "regress out" pre-mRNA abundance and to identify
+  # problematic gene annotations (e.g., regions where estimated pre-mRNA abundance
+  # is as high if not higher than appreciably expressed isoforms).
+  #
+  # The annotation with the full-gene "transcript" will only be used for STAR's alignment
+  # and RSEM quantification. The full-gene transcript will not be a feature to which
+  # reads are assigned by featureCounts.
+quantify_premRNA: False
+
+# String common to spike-in gene_ids in annotation gtf
+  # If you have no spike-ins, then this should be "\"\"", i.e., an empty string ("")
+spikename: "\"\""
+
+
+# Are you using the Windows subsystem for Linux?
+  # Due to a bug in STAR/GNU parallel, tracks have to be created iteratively if this is the case
+WSL: False
+
+
+# Are there jI, jM, XF, GF, or EF tags in provided bam files?
+  # These will break HTSeq or lead to unexpected behavior and will
+  # thus be removed prior to running HTSeq.
+  # NOTE: these tags will not be removed from the input bam files,
+  # just from processed bam files generated by fastq2EZbakR
+remove_tags: False
+
+final_output:
+  cB: True
+  cUP: True
+  arrow: True
+
+##### OTHER FEATURECOUNTS PARAMETERS #####
+# Parameters automatically specified:
+  # Genes: -R -f -g gene_id -t transcript
+  # Exons: -R -g gene_id -J
+  # Transcripts: -R -f -g transcript_id -t exon -O
+  # Exonbins: -R -f -g exon_id -t exonic_part -O
+# If PE = True, then "-p --countReadPairs" is also automatically set
+#
+# !!DO NOT REDUNDANTLY SPECIFY AUTOMATICALLY SPECIFIED PARAMETERS!!
+
+# Parameters for assignment of reads to genes
+fc_genes_extra: "--primary"
+
+# Parameters for assignment of reads to exons
+fc_exons_extra: "--nonOverlap 0 --primary"
+
+# Parameters for assignment of reads to exonbins
+fc_exonbins_extra: "--primary"
+
+# Parameters for assignment of reads to exon-exon junctions
+fc_eej_extra: "--primary"
+
+# Parameters for assignment of reads to exon-intron junctions
+fc_eij_extra: "--primary"
+
+
+##### JUNCTION ANNOTATION PARAMETERS #####
+
+junction_annotation_params: ""
+
+
+
+##### OTHER FASTP PARAMETERS #####
+  # See https://github.com/OpenGene/fastp for details
+
+# Optional parameters to set for fastp
+fastp_parameters: "" 
+
+
+
+##### FASTQC PARAMETERS #####
+  # See https://www.bioinformatics.babraham.ac.uk/projects/fastqc/ for details
+
+# Optional parameters to set for fastqc
+fastqc_params: ""
+
+
+
+##### STAR PARAMETERS #####
+
+# Optional parameters to set for star index
+  # --sjdbGTFfile is automatically set to be the provided annotation file
+star_index_params: "--sjdbOverhang 99"
+
+
+# SAM tags to add to alignment
+star_sam_tags: ["NH", "HI", "AS", "NM", "MD", "nM"]
+
+
+# Optional parameters to set for star align
+  # --sjdbGTFfile is automatically set to be the provided annotation file
+  # --outSAMattributes will also be set and provided the tags specified in `star_sam_tags`, overwriting whatever is set here
+  # Finally, --outSAMType will be force set to BAM SortedByCoordinate, overwriting whatever is set here
+star_align_params: "--outFilterType BySJout"
+
+
+
+##### HISAT2 PARAMETERS #####
+
+# Optional parameters to set for hisat2 indexing
+hisat2_index_params: ""
+
+
+# Optional parmaeters to set for hisat2 alignment
+  # NOTE: --rna-strandedness is automatically set based on required strandedness parameter
+    # DON'T REDUNDANTLY SPECIFY --rna-strandedness HERE!!
+hisat2_align_params: ""
+
+
+# Index base name. If not specified, defaults to "hisat2_index"
+hisat2_index_base: ""
+
+
+
+##### RSEM PARAMETERS #####
+
+# Optional parameters to set for RSEM indexing
+rsem_index_params: ""
+
+
+# Optional parameters to set for RSEM quantification
+rsem_quant_params: ""
+
+
+##### RSEM+ parameters #####
+
+# New read mutation rates
+# If set to -1, then rates will be estimated by model
+# Set rate to 0 if -s4U sample
+pnews:
+    WT_1: 0.05 
+    WT_2: 0.05
+    WT_ctl: 0
+
+# Old read mutation rates
+# If set to -1, then rates will be estimated by model
+# Set rate to 0 if -s4U sample
+polds:
+    WT_1: 0.001
+    WT_2: 0.001
+    WT_ctl: 0
+
+
+##### SITE-SPECIFIC MUTATION CALLING PARAMETERS #####
+
+min_pos_coverage: 1
+max_pos_coverage: 100000
+
+##### LINKS TO SNAKEMAKE WRAPPERS USED #####
+  # Can be useful to see how optional parameters get passed to these tools
+
+# fastp wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/fastp.html
+
+# fastqc wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/fastqc.html

--- a/.test/configs/lowram_arrow_config.yaml
+++ b/.test/configs/lowram_arrow_config.yaml
@@ -1,0 +1,309 @@
+####### GENERAL INFORMATION ABOUT THIS CONFIG #######
+#
+# This config file allows you to specify a number of important pieces of information that
+# the fastq2EZbakR pipeline will require to run. It also allows you to set optional parameters
+# for all tools that fastq2EZbakR makes use of.
+#
+# File paths can either be absolute (e.g., ~/path/to/file/or/directory) or relative
+# to the directory in which you are calling the pipeline from (e.g., data/fastq/WT_1 in the 
+# example samples entry means to look in the data directory present in the directory
+# where you called `snakemake` to run the pipeline).
+#
+####### PARAMETERS YOU NEED TO SET #######
+
+# Run bam2bakR only? If true, will expect paths to bam files as input and alignment steps will be skipped. If false,
+# paths to directories containing fastq files will be expected as input.
+bam2bakr: False
+
+## Paths to data to process
+# path to directory containing fastq files if bam2bakr is False
+  # fastq files can be either gzipped or unzipped
+  # Each set of fastq files must be in a different directory
+# path to bam files if bam2bakr is True
+samples:
+    WT_1: data/WT1
+    WT_2: data/WT2
+    WT_ctl: data/WTctl
+
+## example of what samples will look like for fastq input
+# samples:
+#   WT_1: data/fastq/WT_1
+#   WT_2: data/fastq/WT_2
+#   WT_ctl: data/fastq/WT_ctl
+#   KO_1: data/fastq/KO_1
+#   KO_2: data/fastq/KO_2
+#   KO_ctl: data/fastq/KO_ctl
+
+
+# -s4U control sample IDs
+control_samples: ['WT_ctl']
+
+# Paired end? 
+  # Set to True or False, no double quotes
+PE: True
+
+# Path to genome fasta file
+genome: data/genome/genome.fasta
+
+
+# Path to annotation gtf file
+annotation: data/annotation/genome.gtf
+
+
+# Which aligner to use? 
+  # Options are:
+    # 1) star
+    # 2) hisat2
+aligner: "star"
+
+
+# Path to directory containing indices
+  # Indices will be built automatically if not present
+  # I would suggest naming this "aligner"_index, though any
+  # directory path name will do (avoid results/...; the 
+  # results/ directory is where the pipeline output will be created,
+  # so probably better to avoid specifying a path there that might
+  # clash with the names of one of the other automatically created
+  # directories). 
+indices: star_index
+
+
+# Strandedness
+  # set to "reverse", "yes", or "no"
+  # reverse means that read 2 represents 5' to 3' sequence of original RNA (read 1 thus represents its reverse complement)
+  # yes means that read 1 represents 5' to 3' sequence of original RNA
+  # no means unstranded
+  # Used by HTSeq (see https://htseq.readthedocs.io/en/master/htseqcount.html for details)
+strandedness: "reverse"
+
+final_output:
+  cB: False
+  cUP: False
+  arrow: True
+
+# Augmentative analysis strategies
+  # Transcripts:
+    # Only compatible with STAR alignment.
+    # Final cB will have a column named "transcripts" which will indicate the set of transcripts that each read is 
+    # compatible with. This can be used in conjunction with bakR to perform transcript-isoform specific kinetic parameter
+    # estimates.
+  # FlatStacks:
+    # Flatten annotation with DEXSeq and have a column in the final cB correspond to assignment of reads to exonic
+    # bins. Useful to identify certain isoform-specific effects.
+  # RSEM+:
+    # Onloy compatible with STAR alignment.
+    # Estimate kinetic parameters for transcript isoforms by combining RSEM quantification with bakR's statistical model.
+strategies:
+    RSEMp: True
+    Transcripts: True
+
+# Features to quantify
+features:
+    genes: True
+    exons: True
+    transcripts: True
+    exonic_bins: False
+    junctions: True
+    eij: True
+    eej: True
+
+
+# Merge mutation counts and feature assignments in a RAM-efficient manner?
+  # Downside is that it's a bit slower
+lowRAM: True
+
+####### OPTIONAL PARAMETERS FOR EACH TOOL USED #######
+
+
+##### PARAMETERS MOST WORTH DOUBLE CHECKING #####
+
+# Adapters to pass to fastp 
+  # Not strictly necessary as fastp can autodetect. Autodetection is more accurate for paired-end data
+  # For paired-end data with widely used Illumina TruSeq adapters, this could be: 
+  # "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+fastp_adapters: ""
+
+
+# Normalize sequencing tracks?
+normalize: False
+
+
+# Path to flattened annotation 
+# Will be created if not already present
+# Only relevant if using FlatStacks
+flat_annotation: "data/annotation/flat.gtf"
+
+
+# Track site-specific mutational information
+mutpos: False
+
+
+# Add a full-gene "transcript" to annotation used for STAR + RSEM to quantify pre-mRNA.
+  # This is a nice way to "regress out" pre-mRNA abundance and to identify
+  # problematic gene annotations (e.g., regions where estimated pre-mRNA abundance
+  # is as high if not higher than appreciably expressed isoforms).
+  #
+  # The annotation with the full-gene "transcript" will only be used for STAR's alignment
+  # and RSEM quantification. The full-gene transcript will not be a feature to which
+  # reads are assigned by featureCounts.
+quantify_premRNA: False
+
+
+# Types of mutations to make tracks for otherwise
+  # Comma separated string of mutation type
+  # Examples:
+    # "TC"
+      # count T-to-C mutations
+    # "TC,GA"
+      # counts T-to-C and G-to-A mutations
+mut_tracks: "TC"
+
+
+# Minimum base quality to call mutation
+minqual: 40
+
+
+# String common to spike-in gene_ids in annotation gtf
+  # If you have no spike-ins, then this should be "\"\"", i.e., an empty string ("")
+spikename: "\"\""
+
+
+# Are you using the Windows subsystem for Linux?
+  # Due to a bug in STAR/GNU parallel, tracks have to be created iteratively if this is the case
+WSL: False
+
+
+# Are there jI, jM, XF, GF, or EF tags in provided bam files?
+  # These will break HTSeq or lead to unexpected behavior and will
+  # thus be removed prior to running HTSeq.
+  # NOTE: these tags will not be removed from the input bam files,
+  # just from processed bam files generated by fastq2EZbakR
+remove_tags: True
+
+
+##### OTHER FEATURECOUNTS PARAMETERS #####
+# Parameters automatically specified:
+  # Genes: -R -f -g gene_id -t transcript
+  # Exons: -R -g gene_id -J
+  # Transcripts: -R -f -g transcript_id -t exon -O
+  # Exonbins: -R -f -g exon_id -t exonic_part -O
+# If PE = True, then "-p --countReadPairs" is also automatically set
+#
+# !!DO NOT REDUNDANTLY SPECIFY AUTOMATICALLY SPECIFIED PARAMETERS!!
+
+# Parameters for assignment of reads to genes
+fc_genes_extra: "--primary"
+
+# Parameters for assignment of reads to exons
+fc_exons_extra: "--nonOverlap 0 --primary"
+
+# Parameters for assignment of reads to transcripts
+fc_transcripts_extra: "--nonOverlap 0 --primary"
+
+# Parameters for assignment of reads to exonbins
+fc_exonbins_extra: "--primary"
+
+# Parameters for assignment of reads to exon-exon junctions
+fc_eej_extra: "--primary"
+
+# Parameters for assignment of reads to exon-intron junctions
+fc_eij_extra: "--primary"
+
+##### OTHER FASTP PARAMETERS #####
+  # See https://github.com/OpenGene/fastp for details
+
+# Optional parameters to set for fastp
+fastp_parameters: "" 
+
+
+##### JUNCTION ANNOTATION PARAMETERS #####
+
+junction_annotation_params: ""
+
+##### FASTQC PARAMETERS #####
+  # See https://www.bioinformatics.babraham.ac.uk/projects/fastqc/ for details
+
+# Optional parameters to set for fastqc
+fastqc_params: ""
+
+
+
+##### STAR PARAMETERS #####
+
+# Optional parameters to set for star index
+  # --sjdbGTFfile is automatically set to be the provided annotation file
+star_index_params: "--sjdbOverhang 99"
+
+
+# SAM tags to add to alignment
+star_sam_tags: ["NH", "HI", "AS", "NM", "MD", "nM", "jI", "jM"]
+
+
+# Optional parameters to set for star align
+  # --sjdbGTFfile is automatically set to be the provided annotation file
+  # --outSAMattributes will also be set and provided the tags specified in `star_sam_tags`, overwriting whatever is set here
+  # Finally, --outSAMType will be force set to BAM SortedByCoordinate, overwriting whatever is set here
+  # We suggest turning off soft-clipping to improve assignment of reads to exons
+star_align_params: "--alignEndsType Local"
+
+
+
+##### HISAT2 PARAMETERS #####
+
+# Optional parameters to set for hisat2 indexing
+hisat2_index_params: ""
+
+
+# Optional parmaeters to set for hisat2 alignment
+  # NOTE: --rna-strandedness is automatically set based on required strandedness parameter
+    # DON'T REDUNDANTLY SPECIFY --rna-strandedness HERE!!
+  # We suggest turning off soft-clipping to improve assignment of reads to exons
+hisat2_align_params: "--no-softclip"
+
+
+
+# Index base name. If not specified, defaults to "hisat2_index"
+hisat2_index_base: ""
+
+
+
+##### RSEM PARAMETERS #####
+
+# Optional parameters to set for RSEM indexing
+rsem_index_params: ""
+
+
+# Optional parameters to set for RSEM quantification
+rsem_quant_params: ""
+
+
+##### RSEM+ parameters #####
+
+# New read mutation rates
+# If set to -1, then rates will be estimated by model
+# Set rate to 0 if -s4U sample
+pnews:
+    WT_1: 0.05 
+    WT_2: 0.05
+    WT_ctl: 0
+
+# Old read mutation rates
+# If set to -1, then rates will be estimated by model
+# Set rate to 0 if -s4U sample
+polds:
+    WT_1: 0.001
+    WT_2: 0.001
+    WT_ctl: 0
+
+
+##### SITE-SPECIFIC MUTATION CALLING PARAMETERS #####
+
+min_pos_coverage: 1
+max_pos_coverage: 100000
+
+##### LINKS TO SNAKEMAKE WRAPPERS USED #####
+  # Can be useful to see how optional parameters get passed to these tools
+
+# fastp wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/fastp.html
+
+# fastqc wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/fastqc.html

--- a/.test/configs/nocB_config.yaml
+++ b/.test/configs/nocB_config.yaml
@@ -1,0 +1,303 @@
+####### GENERAL INFORMATION ABOUT THIS CONFIG #######
+#
+# This config file allows you to specify a number of important pieces of information that
+# the fastq2EZbakR pipeline will require to run. It also allows you to set optional parameters
+# for all tools that fastq2EZbakR makes use of.
+#
+# File paths can either be absolute (e.g., ~/path/to/file/or/directory) or relative
+# to the directory in which you are calling the pipeline from (e.g., data/fastq/WT_1 in the 
+# example samples entry means to look in the data directory present in the directory
+# where you called `snakemake` to run the pipeline).
+#
+####### PARAMETERS YOU NEED TO SET #######
+
+
+## Paths to data to process
+# path to directory containing fastq files if bam2bakr is False
+  # fastq files can be either gzipped or unzipped
+  # Each set of fastq files must be in a different directory
+# path to bam files if bam2bakr is True
+samples:
+    WT_1: data/bams/WT_replicate_1.bam
+    WT_2: data/bams/WT_replicate_2.bam
+    WT_ctl: data/bams/WT_nos4U.bam
+
+## example of what samples will look like for fastq input
+# samples:
+#   WT_1: data/fastq/WT_1
+#   WT_2: data/fastq/WT_2
+#   WT_ctl: data/fastq/WT_ctl
+#   KO_1: data/fastq/KO_1
+#   KO_2: data/fastq/KO_2
+#   KO_ctl: data/fastq/KO_ctl
+
+
+# -s4U control sample IDs
+control_samples: ['WT_ctl']
+
+# Paired end? 
+  # Set to True or False, no double quotes
+PE: True
+
+# Path to genome fasta file
+genome: data/genome/genome.fasta
+
+
+# Path to annotation gtf file
+annotation: data/annotation/genome.gtf
+
+
+# Which aligner to use? 
+  # Options are:
+    # 1) star
+    # 2) hisat2
+aligner: "hisat2"
+
+
+# Path to directory containing indices
+  # Indices will be built automatically if not present
+  # I would suggest naming this "aligner"_index, though any
+  # directory path name will do (avoid results/...; the 
+  # results/ directory is where the pipeline output will be created,
+  # so probably better to avoid specifying a path there that might
+  # clash with the names of one of the other automatically created
+  # directories). 
+indices: star_index
+
+
+# Strandedness
+  # set to "reverse", "yes", or "no"
+  # reverse means that read 2 represents 5' to 3' sequence of original RNA (read 1 thus represents its reverse complement)
+  # yes means that read 1 represents 5' to 3' sequence of original RNA
+  # no means unstranded
+  # Used by HTSeq (see https://htseq.readthedocs.io/en/master/htseqcount.html for details)
+strandedness: "reverse"
+
+
+# Augmentative analysis strategies
+  # Transcripts:
+    # Only compatible with STAR alignment.
+    # Final cB will have a column named "transcripts" which will indicate the set of transcripts that each read is 
+    # compatible with. This can be used in conjunction with bakR to perform transcript-isoform specific kinetic parameter
+    # estimates.
+  # FlatStacks:
+    # Flatten annotation with DEXSeq and have a column in the final cB correspond to assignment of reads to exonic
+    # bins. Useful to identify certain isoform-specific effects.
+  # RSEM+:
+    # Onloy compatible with STAR alignment.
+    # Estimate kinetic parameters for transcript isoforms by combining RSEM quantification with bakR's statistical model.
+strategies:
+    RSEMp: False
+    Transcripts: False
+
+
+# Features to quantify
+features:
+    genes: True
+    exons: True
+    transcripts: True
+    exonic_bins: True
+    junctions: False
+    eij: False
+    eej: False
+
+
+# Merge mutation counts and feature assignments in a RAM-efficient manner?
+  # Downside is that it's a bit slower
+lowRAM: False
+
+####### OPTIONAL PARAMETERS FOR EACH TOOL USED #######
+
+
+##### PARAMETERS MOST WORTH DOUBLE CHECKING #####
+
+# Adapters to pass to fastp 
+  # Not strictly necessary as fastp can autodetect. Autodetection is more accurate for paired-end data
+  # For paired-end data with widely used Illumina TruSeq adapters, this could be: 
+  # "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+fastp_adapters: ""
+
+
+# Path to flattened annotation 
+# Will be created if not already present
+# Only relevant if using FlatStacks
+flat_annotation: "data/annotation/flat_b2b.gtf"
+
+# Track site-specific mutational information
+mutpos: False
+
+# Normalize sequencing tracks?
+normalize: True
+
+
+
+# Types of mutations to make tracks for otherwise
+  # Comma separated string of mutation type
+  # Examples:
+    # "TC"
+      # count T-to-C mutations
+    # "TC,GA"
+      # counts T-to-C and G-to-A mutations
+mut_tracks: "TC"
+
+
+# Minimum base quality to call mutation
+minqual: 40
+
+
+# Add a full-gene "transcript" to annotation used for STAR + RSEM to quantify pre-mRNA.
+  # This is a nice way to "regress out" pre-mRNA abundance and to identify
+  # problematic gene annotations (e.g., regions where estimated pre-mRNA abundance
+  # is as high if not higher than appreciably expressed isoforms).
+  #
+  # The annotation with the full-gene "transcript" will only be used for STAR's alignment
+  # and RSEM quantification. The full-gene transcript will not be a feature to which
+  # reads are assigned by featureCounts.
+quantify_premRNA: False
+
+# String common to spike-in gene_ids in annotation gtf
+  # If you have no spike-ins, then this should be "\"\"", i.e., an empty string ("")
+spikename: "\"\""
+
+
+# Are you using the Windows subsystem for Linux?
+  # Due to a bug in STAR/GNU parallel, tracks have to be created iteratively if this is the case
+WSL: False
+
+
+# Are there jI, jM, XF, GF, or EF tags in provided bam files?
+  # These will break HTSeq or lead to unexpected behavior and will
+  # thus be removed prior to running HTSeq.
+  # NOTE: these tags will not be removed from the input bam files,
+  # just from processed bam files generated by fastq2EZbakR
+remove_tags: False
+
+final_output:
+  cB: False
+  cUP: True
+  arrow: True
+
+##### OTHER FEATURECOUNTS PARAMETERS #####
+# Parameters automatically specified:
+  # Genes: -R -f -g gene_id -t transcript
+  # Exons: -R -g gene_id -J
+  # Transcripts: -R -f -g transcript_id -t exon -O
+  # Exonbins: -R -f -g exon_id -t exonic_part -O
+# If PE = True, then "-p --countReadPairs" is also automatically set
+#
+# !!DO NOT REDUNDANTLY SPECIFY AUTOMATICALLY SPECIFIED PARAMETERS!!
+
+# Parameters for assignment of reads to genes
+fc_genes_extra: "--primary"
+
+# Parameters for assignment of reads to exons
+fc_exons_extra: "--nonOverlap 0 --primary"
+
+# Parameters for assignment of reads to exonbins
+fc_exonbins_extra: "--primary"
+
+# Parameters for assignment of reads to exon-exon junctions
+fc_eej_extra: "--primary"
+
+# Parameters for assignment of reads to exon-intron junctions
+fc_eij_extra: "--primary"
+
+
+##### JUNCTION ANNOTATION PARAMETERS #####
+
+junction_annotation_params: ""
+
+
+
+##### OTHER FASTP PARAMETERS #####
+  # See https://github.com/OpenGene/fastp for details
+
+# Optional parameters to set for fastp
+fastp_parameters: "" 
+
+
+
+##### FASTQC PARAMETERS #####
+  # See https://www.bioinformatics.babraham.ac.uk/projects/fastqc/ for details
+
+# Optional parameters to set for fastqc
+fastqc_params: ""
+
+
+
+##### STAR PARAMETERS #####
+
+# Optional parameters to set for star index
+  # --sjdbGTFfile is automatically set to be the provided annotation file
+star_index_params: "--sjdbOverhang 99"
+
+
+# SAM tags to add to alignment
+star_sam_tags: ["NH", "HI", "AS", "NM", "MD", "nM"]
+
+
+# Optional parameters to set for star align
+  # --sjdbGTFfile is automatically set to be the provided annotation file
+  # --outSAMattributes will also be set and provided the tags specified in `star_sam_tags`, overwriting whatever is set here
+  # Finally, --outSAMType will be force set to BAM SortedByCoordinate, overwriting whatever is set here
+star_align_params: "--outFilterType BySJout"
+
+
+
+##### HISAT2 PARAMETERS #####
+
+# Optional parameters to set for hisat2 indexing
+hisat2_index_params: ""
+
+
+# Optional parmaeters to set for hisat2 alignment
+  # NOTE: --rna-strandedness is automatically set based on required strandedness parameter
+    # DON'T REDUNDANTLY SPECIFY --rna-strandedness HERE!!
+hisat2_align_params: ""
+
+
+# Index base name. If not specified, defaults to "hisat2_index"
+hisat2_index_base: ""
+
+
+
+##### RSEM PARAMETERS #####
+
+# Optional parameters to set for RSEM indexing
+rsem_index_params: ""
+
+
+# Optional parameters to set for RSEM quantification
+rsem_quant_params: ""
+
+
+##### RSEM+ parameters #####
+
+# New read mutation rates
+# If set to -1, then rates will be estimated by model
+# Set rate to 0 if -s4U sample
+pnews:
+    WT_1: 0.05 
+    WT_2: 0.05
+    WT_ctl: 0
+
+# Old read mutation rates
+# If set to -1, then rates will be estimated by model
+# Set rate to 0 if -s4U sample
+polds:
+    WT_1: 0.001
+    WT_2: 0.001
+    WT_ctl: 0
+
+
+##### SITE-SPECIFIC MUTATION CALLING PARAMETERS #####
+
+min_pos_coverage: 1
+max_pos_coverage: 100000
+
+##### LINKS TO SNAKEMAKE WRAPPERS USED #####
+  # Can be useful to see how optional parameters get passed to these tools
+
+# fastp wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/fastp.html
+
+# fastqc wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/fastqc.html

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -85,6 +85,7 @@ indices: data/indices/star_index
 
 # Strandedness
   # set to "reverse", "yes", or "no"
+  # Instead of "yes", can now use "forward" as well (both will have the same result)
   # reverse means that read 2 represents 5' to 3' sequence of original RNA (read 1 thus represents its reverse complement)
   # yes means that read 1 represents 5' to 3' sequence of original RNA
   # no means unstranded

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -172,6 +172,23 @@ mutpos: False
 run_rsem: True
 
 
+# What final output do you want pipeline to create?
+  # cB = standard cB file tracking number of mutations and number of mutable reference nucleotides in each read.
+  # cUP = remove the mutable reference nucleotide count and instead compute the average of this value for reads
+  #         with the same mutational content. This is orders of magnitude more compressed than a cB file (typically
+  #         around 100x smaller), and is still compatible with EZbakR. Downside is the slight information loss that
+  #         this compression leads to.
+  # arrow = Partitioned database of parquet files, in the format necessary to pass to EZbakR.
+  # 
+  # At least one of these should be set to True.
+  # If lowRAM == False, any combination of these can be set to True (including all True).
+  # If lowRAM == True, cB and cUP can not both be true.
+final_output:
+  cB: True
+  cUP: False
+  arrow: False
+
+
 ####### OPTIONAL PARAMETERS FOR THE VARIOUS TOOLS AND SCRIPTS USED #######
 
 ##### FEATURECOUNTS PARAMETERS #####

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -114,16 +114,13 @@ features:
     eij: False
 
 
-####### ADDITIONAL PARAMETERS TO TUNE PIPELINE FUNCTION AND THE VARIOUS TOOLS USED #######
-
-
-##### PARAMETERS MOST WORTH DOUBLE CHECKING #####
+####### PARAMETERS THAT TUNE ASPECTS OF PIPELINE BEHAVIOR, BUT WITH LIKELY REASONABLE DEFAULTS #######
 
 # Types of mutations to make tracks for otherwise
   # Comma separated string of mutation type
   # Examples:
     # "TC"
-      # count T-to-C mutations
+      # counts T-to-C mutations
     # "TC,GA"
       # counts T-to-C and G-to-A mutations
 mut_tracks: "TC"
@@ -132,29 +129,25 @@ mut_tracks: "TC"
 # Normalize sequencing tracks?
 normalize: True
 
+
 # String common to spike-in gene_ids in annotation gtf
   # If you have no spike-ins, then this should be "\"\"", i.e., an empty string ("")
+  # Used for normalization of tracks. Thus, only relevant if normalize == True
 spikename: "\"\""
 
 
-# Skip adapter trimming? If True, will skip fastp step
+# Skip adapter trimming? 
+  # If True, will skip fastp step
 skip_trimming: False
 
 
-# Adapters to pass to fastp 
-  # Not strictly necessary as fastp can autodetect. Autodetection is more accurate for paired-end data
-  # For paired-end data with widely used Illumina TruSeq adapters, this could be: 
-  # "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
-fastp_adapters: ""
-
-
 # Path to flattened annotation 
-# Will be created if not already present
-# Only relevant if assigning reads to exonic_bins
+  # Will be created if not already present
+  # Only relevant if assigning reads to exonic_bins
 flat_annotation: "data/annotation/flat.gtf"
 
 
-# Minimum base quality to call mutation
+# Minimum base quality required to call mutation
 minqual: 40
 
 
@@ -168,17 +161,20 @@ WSL: False
 lowRAM: False
 
 
-# Track site-specific mutational content
+# Track site-specific mutational content?
   # Not currently compatible with lowRAM = True
 mutpos: False
 
 
-# Use RSEM to quantify transcript isoform abundances
+# Use RSEM to quantify transcript isoform abundances?
   # Only relevant if aligner = 'star' and fastq files are
   # provided as input
 run_rsem: True
 
-##### OTHER FEATURECOUNTS PARAMETERS #####
+
+####### OPTIONAL PARAMETERS FOR THE VARIOUS TOOLS AND SCRIPTS USED #######
+
+##### FEATURECOUNTS PARAMETERS #####
 # Parameters automatically specified:
   # Genes: -R -f -g gene_id -t transcript
   # Exons: -R -g gene_id -J
@@ -214,20 +210,18 @@ fc_eej_extra: "-M"
 fc_eij_extra: "-M"
 
 
-##### JUNCTION ANNOTATION PARAMETERS #####
-
-# Currently no adjustable parameters for this, but eventually there
-# will be.
-junction_annotation_params: ""
-
-
-
-##### OTHER FASTP PARAMETERS #####
+##### FASTP PARAMETERS #####
   # See https://github.com/OpenGene/fastp for details
+
+# Adapters to pass to fastp 
+  # Not strictly necessary as fastp can autodetect adapters. Autodetection is more accurate for paired-end data though.
+  # For paired-end data with widely used Illumina TruSeq adapters, this could be: 
+  # "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+fastp_adapters: ""
+
 
 # Optional parameters to set for fastp
 fastp_parameters: "" 
-
 
 
 ##### FASTQC PARAMETERS #####
@@ -303,6 +297,12 @@ min_pos_coverage: 1
 max_pos_coverage: 10000000
 
 
+
+##### JUNCTION ANNOTATION PARAMETERS #####
+
+# Currently no adjustable parameters for this, but eventually there
+# will be.
+junction_annotation_params: ""
 
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -43,6 +43,9 @@ if "transcripts" not in config["features"]:
 if "fc_transcripts_extra" not in config:
     config["fc_transcripts_extra"] = ""
 
+if "final_output" not in config:
+    config["final_output"] = {"cB": True, "cUP": False, "arrow": False}
+
 ##### setup report #####
 
 

--- a/workflow/envs/full.yaml
+++ b/workflow/envs/full.yaml
@@ -29,3 +29,4 @@ dependencies:
   - bioconductor-rtracklayer
   - r-r.utils
   - r-data.table
+  - r-arrow

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -323,13 +323,13 @@ rule makecUP:
         """
         ### GOAL: Concatenate but make sure that headers get removed before concatenation.
 
-        head -n 1 {input.cUPins[0]} > temp_header.txt
+        head -n 1 {input.cUPins[0]} > temp_cUP_header.txt
         
         # Prepare an empty, gzipped file for the output
         : > {output.cUP}
         
         # Compress the header and add to the output file
-        pigz -c temp_header.txt >> {output.cUP}
+        pigz -c temp_cUP_header.txt >> {output.cUP}
         
         # Iterate over all files, decompress, skip headers, and append to the output file
         for file in {input.cUPins}; do
@@ -337,7 +337,7 @@ rule makecUP:
         done
         
         # Cleanup the temporary header file
-        rm temp_header.txt
+        rm temp_cUP_header.txt
         """
 
 

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -203,12 +203,17 @@ rule cnt_muts:
 if not config["lowRAM"]:
 
     # Merge mutation counts with feature assignment
+    # Bit of a cheap hack here where I didn't want to deal with dynamically
+    # deciding the output, so I just create all files by default, with the ones
+    # not requested by the user being temporary empty files.
     rule merge_features_and_muts:
         input:
             get_merge_input,
         output:
             output="results/merge_features_and_muts/{sample}_counts.csv.gz",
             cBout=temp("results/merge_features_and_muts/{sample}_cB.csv"),
+            cUPout = temp("results/merge_features_and_muts/{sample}_cUP.csv"),
+            Arrowout = "results/arrow_dataset/sample={sample}/part-0.parquet"
         params:
             genes_included=config["features"]["genes"],
             exons_included=config["features"]["exons"],
@@ -223,6 +228,9 @@ if not config["lowRAM"]:
             ),
             muttypes=config["mut_tracks"],
             annotation=config["annotation"],
+            makecB = config["final_output"]["cB"],
+            makecUP = config["final_output"]["cUP"],
+            makeArrow = config["final_output"]["arrow"],
         log:
             "logs/merge_features_and_muts/{sample}.log",
         threads: 8
@@ -235,7 +243,9 @@ if not config["lowRAM"]:
             {params.rscript} -g {params.genes_included} -e {params.exons_included} -b {params.exonbins_included} \
             -t {params.transcripts_included} --frombam {params.bamfiletranscripts_included} -o {output.output} -s {wildcards.sample} \
             -j {params.eej_included} --starjunc {params.starjunc_included} --eij {params.eij_included} \
-            --annotation {params.annotation} -c {output.cBout} -m {params.muttypes} 1> {log} 2>&1
+            --annotation {params.annotation} -c {output.cBout} -m {params.muttypes} \
+            --makecB {params.makecB} --makecUP {params.makecUP} --makeArrow {params.makeArrow} \
+            --cUPout {output.cUPout} --Arrowout {output.Arrowout} 1> {log} 2>&1
             """
 
 

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -299,6 +299,38 @@ rule makecB:
         """
 
 
+rule makecUP:
+    input:
+        cUPins=CUPINPUT,
+    output:
+        cUP="results/cUP/cUP.csv.gz",
+    log:
+        "logs/makecUP/makecUP.log",
+    threads: 8
+    conda:
+        "../envs/full.yaml"
+    shell:
+        """
+        ### GOAL: Concatenate but make sure that headers get removed before concatenation.
+
+        head -n 1 {input.cUPins[0]} > temp_header.txt
+        
+        # Prepare an empty, gzipped file for the output
+        : > {output.cUP}
+        
+        # Compress the header and add to the output file
+        pigz -c temp_header.txt >> {output.cUP}
+        
+        # Iterate over all files, decompress, skip headers, and append to the output file
+        for file in {input.cUPins}; do
+            tail -n +2 ${{file}} | pigz -c >> {output.cUP}
+        done
+        
+        # Cleanup the temporary header file
+        rm temp_header.txt
+        """
+
+
 # Make color-coded tracks
 rule maketdf:
     input:

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -212,8 +212,8 @@ if not config["lowRAM"]:
         output:
             output="results/merge_features_and_muts/{sample}_counts.csv.gz",
             cBout=temp("results/merge_features_and_muts/{sample}_cB.csv"),
-            cUPout = temp("results/merge_features_and_muts/{sample}_cUP.csv"),
-            Arrowout = "results/arrow_dataset/sample={sample}/part-0.parquet"
+            cUPout=temp("results/merge_features_and_muts/{sample}_cUP.csv"),
+            Arrowout="results/arrow_dataset/sample={sample}/part-0.parquet",
         params:
             genes_included=config["features"]["genes"],
             exons_included=config["features"]["exons"],
@@ -228,9 +228,9 @@ if not config["lowRAM"]:
             ),
             muttypes=config["mut_tracks"],
             annotation=config["annotation"],
-            makecB = config["final_output"]["cB"],
-            makecUP = config["final_output"]["cUP"],
-            makeArrow = config["final_output"]["arrow"],
+            makecB=config["final_output"]["cB"],
+            makecUP=config["final_output"]["cUP"],
+            makeArrow=config["final_output"]["arrow"],
         log:
             "logs/merge_features_and_muts/{sample}.log",
         threads: 8

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -559,14 +559,13 @@ if not any(config["final_output"].values()):
 
 # lowRAM can only work with a single type of output
 if config["lowRAM"]:
-
     if sum(config["final_output"].values()) > 1:
-
-        raise ValueError("If lowRAM = True, then can only specify a single final_output option as True!")
+        raise ValueError(
+            "If lowRAM = True, then can only specify a single final_output option as True!"
+        )
 
     if config["final_output"]["cUP"]:
         raise ValueError("lowRAM = True is not currently compatible with cUP output!")
-
 
 
 def get_other_output():
@@ -579,9 +578,7 @@ def get_other_output():
         target.append("results/cUP/cUP.csv.gz")
 
     if config["final_output"]["arrow"]:
-
         if config["lowRAM"]:
-
             target.append(
                 expand(
                     "results/arrow_dataset/sample={sample}/part-0.csv",
@@ -590,7 +587,6 @@ def get_other_output():
             )
 
         else:
-
             target.append(
                 expand(
                     "results/arrow_dataset/sample={sample}/part-0.parquet",

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -487,7 +487,7 @@ def get_merge_input(wildcards):
 if config["strandedness"] == "reverse":
     FC_STRAND = 2
 
-elif config["strandedness"] == "yes":
+elif config["strandedness"] == "yes" or config["strandedness"] == "forward":
     FC_STRAND = 1
 
 else:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -557,23 +557,21 @@ else:
 if not any(config["final_output"].values()):
     raise ValueError("One of final_output values must be True!")
 
+
 def get_other_output():
     target = []
 
-    if(config["final_output"]["cB"]):
-
+    if config["final_output"]["cB"]:
         target.append("results/cB/cB.csv.gz")
 
-    if(config["final_output"]["cUP"]):
-
+    if config["final_output"]["cUP"]:
         target.append("results/cUP/cUP.csv.gz")
 
-    if(config["final_output"]["arrow"]):
-
+    if config["final_output"]["arrow"]:
         target.append(
             expand(
                 "results/arrow_dataset/sample={sample}/part-0.parquet",
-                sample = SAMP_NAMES
+                sample=SAMP_NAMES,
             )
         )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -557,6 +557,17 @@ else:
 if not any(config["final_output"].values()):
     raise ValueError("One of final_output values must be True!")
 
+# lowRAM can only work with a single type of output
+if config["lowRAM"]:
+
+    if sum(config["final_output"].values()) > 1:
+
+        raise ValueError("If lowRAM = True, then can only specify a single final_output option as True!")
+
+    if config["final_output"]["cUP"]:
+        raise ValueError("lowRAM = True is not currently compatible with cUP output!")
+
+
 
 def get_other_output():
     target = []
@@ -568,12 +579,24 @@ def get_other_output():
         target.append("results/cUP/cUP.csv.gz")
 
     if config["final_output"]["arrow"]:
-        target.append(
-            expand(
-                "results/arrow_dataset/sample={sample}/part-0.parquet",
-                sample=SAMP_NAMES,
+
+        if config["lowRAM"]:
+
+            target.append(
+                expand(
+                    "results/arrow_dataset/sample={sample}/part-0.csv",
+                    sample=SAMP_NAMES,
+                )
             )
-        )
+
+        else:
+
+            target.append(
+                expand(
+                    "results/arrow_dataset/sample={sample}/part-0.parquet",
+                    sample=SAMP_NAMES,
+                )
+            )
 
     # Tracks always get made
     target.append(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -553,12 +553,29 @@ else:
 
 ### Target rule input
 
+# Need to specify one of final_output to be True
+if not any(config["final_output"].values()):
+    raise ValueError("One of final_output values must be True!")
 
 def get_other_output():
     target = []
 
-    # cB file always gets made
-    target.append("results/cB/cB.csv.gz")
+    if(config["final_output"]["cB"]):
+
+        target.append("results/cB/cB.csv.gz")
+
+    if(config["final_output"]["cUP"]):
+
+        target.append("results/cUP/cUP.csv.gz")
+
+    if(config["final_output"]["arrow"]):
+
+        target.append(
+            expand(
+                "results/arrow_dataset/sample={sample}/part-0.parquet",
+                sample = SAMP_NAMES
+            )
+        )
 
     # Tracks always get made
     target.append(
@@ -713,6 +730,21 @@ else:
         sample=SAMP_NAMES,
     )
 
+
+### Input for makecUP
+
+if config["lowRAM"]:
+    CUPINPUT = expand(
+        "results/lowram_summarise/{sample}_cB.csv",
+        sample=SAMP_NAMES,
+    )
+
+
+else:
+    CUPINPUT = expand(
+        "results/merge_features_and_muts/{sample}_cUP.csv",
+        sample=SAMP_NAMES,
+    )
 
 ### RSEM plus input
 

--- a/workflow/rules/lowram.smk
+++ b/workflow/rules/lowram.smk
@@ -34,7 +34,7 @@ rule sort_mutcounts_by_qname:
 
         head -n 1 {output.decomp} > {output.sortout}
         
-        tail -n +2 {output.decomp} | sort -S 10% --parallel={threads} -k1 -V >> {output.sortout}
+        tail -n +2 {output.decomp} | sort --parallel={threads} -k1 -V >> {output.sortout}
         """
 
 
@@ -50,7 +50,7 @@ rule sort_fcgene_by_qname:
         "logs/sort_fcgene_by_qname/{sample}.log",
     shell:
         """
-        sort -S 10% --parallel={threads} -k1 -V {input} > {output}
+        sort --parallel={threads} -k1 -V {input} > {output}
         """
 
 
@@ -66,7 +66,7 @@ rule sort_fcexon_by_qname:
         "logs/sort_fcexon_by_qname/{sample}.log",
     shell:
         """
-        sort -S 10% --parallel={threads} -k1 -V {input} > {output}
+        sort --parallel={threads} -k1 -V {input} > {output}
         """
 
 
@@ -88,7 +88,7 @@ rule sort_junction_by_qname:
 
         head -n 1 {output.decomp} > {output.sortout}
         
-        tail -n +2 {output.decomp} | sort -S 10% --parallel={threads} -k1 -V >> {output.sortout}
+        tail -n +2 {output.decomp} | sort  --parallel={threads} -k1 -V >> {output.sortout}
         """
 
 
@@ -104,7 +104,7 @@ rule sort_fcee_by_qname:
         "logs/sort_fcee_by_qname/{sample}.log",
     shell:
         """
-        sort -S 10% --parallel={threads} -k1 -V {input} > {output}
+        sort --parallel={threads} -k1 -V {input} > {output}
         """
 
 
@@ -120,7 +120,7 @@ rule sort_fcei_by_qname:
         "logs/sort_fcei_by_qname/{sample}.log",
     shell:
         """
-        sort -S 10% --parallel={threads} -k1 -V {input} > {output}
+        sort --parallel={threads} -k1 -V {input} > {output}
         """
 
 
@@ -136,7 +136,7 @@ rule sort_fctranscript_by_qname:
         "logs/sort_fctranscript_by_qname/{sample}.log",
     shell:
         """
-        sort -S 10% --parallel={threads} -k1 -V {input} > {output}
+        sort --parallel={threads} -k1 -V {input} > {output}
         """
 
 
@@ -152,7 +152,7 @@ rule sort_fcexonbin_by_qname:
         "logs/sort_fcexonbin_by_qname/{sample}.log",
     shell:
         """
-        sort -S 10% --parallel={threads} -k1 -V {input} > {output}
+        sort --parallel={threads} -k1 -V {input} > {output}
         """
 
 
@@ -171,7 +171,7 @@ rule sort_bamtranscript_by_qname:
         ### GOAL: Sort but preserve header
         head -n 1 {input} > {output}
         
-        tail -n +2 {input} | sort -S 10% --parallel={threads} -k1 -V >> {output}
+        tail -n +2 {input} | sort --parallel={threads} -k1 -V >> {output}
         """
 
 
@@ -218,24 +218,43 @@ rule sort_merged_files:
         """
         head -n 1 {input} > {output}
         
-        tail -n +2 {input} | sort -t, -S 10% --parallel={threads} {params.sortparams} >> {output}
+        tail -n +2 {input} | sort -t, --parallel={threads} {params.sortparams} >> {output}
         """
 
 
 ### SUMMARISE MERGED FILES
 
 
-rule lowram_summarise:
-    input:
-        "results/sort_merged_files/{sample}.csv",
-    output:
-        temp("results/lowram_summarise/{sample}.csv"),
-    params:
-        cols_to_sum=COLS_TO_SUM,
-    threads: 1
-    conda:
-        "../envs/full.yaml"
-    log:
-        "logs/lowram_summarise/{sample}.log",
-    script:
-        "../scripts/lowram/lowram_summarise.py"
+if config["final_output"]["arrow"]:
+
+    rule lowram_summarise:
+        input:
+            "results/sort_merged_files/{sample}.csv",
+        output:
+            "results/arrow_dataset/sample={sample}/part-0.csv",
+        params:
+            cols_to_sum=COLS_TO_SUM,
+        threads: 1
+        conda:
+            "../envs/full.yaml"
+        log:
+            "logs/lowram_summarise/{sample}.log",
+        script:
+            "../scripts/lowram/lowram_summarise.py"
+
+else:
+
+    rule lowram_summarise:
+        input:
+            "results/sort_merged_files/{sample}.csv",
+        output:
+            temp("results/lowram_summarise/{sample}.csv"),
+        params:
+            cols_to_sum=COLS_TO_SUM,
+        threads: 1
+        conda:
+            "../envs/full.yaml"
+        log:
+            "logs/lowram_summarise/{sample}.log",
+        script:
+            "../scripts/lowram/lowram_summarise.py"

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -22,7 +22,7 @@ if config["PE"]:
             "logs/fastp/{sample}.log",
         params:
             adapters=config["fastp_adapters"],
-            extra="",
+            extra=config["fastp_parameters"],
         threads: 8
         wrapper:
             "v2.2.1/bio/fastp"
@@ -42,7 +42,7 @@ else:
             "logs/fastp/{sample}.log",
         params:
             adapters=config["fastp_adapters"],
-            extra="",
+            extra=config["fastp_parameters"],
         threads: 8
         wrapper:
             "v2.2.1/bio/fastp"

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -417,6 +417,11 @@ if(opt$makecB){
   write_csv(muts,
             file = opt$cBoutput)
 
+}else{
+
+  write_csv(tibble(),
+            file = opt$cBoutput)
+
 }
 
 if(opt$makecUP){
@@ -434,12 +439,24 @@ if(opt$makecUP){
   write_csv(cUP,
             file = opt$cUPoutput)
 
+}else{
+
+  write_csv(tibble(),
+            file = opt$cUPoutput)
+
 }
+
 
 if(opt$makeArrow){
 
   library(arrow)
   write_parquet(muts,
+                opt$Arrowoutput)
+
+}else{
+
+  library(arrow)
+  write_parquet(tibble(),
                 opt$Arrowoutput)
 
 }

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -63,7 +63,7 @@ option_list <- list(
   make_option(c("--cUPoutput", type = "character"),
               help = "Path to cUP output; same as full output with some columns averaged out."),
   make_option(c("--Arrowoutput", type = "character"),
-              help = "Path to arrow parquet file output; same as full output with some columns averaged out."),
+              help = "Path to arrow parquet file output; same as full output with some columns averaged out.")
 )
 
 opt_parser <- OptionParser(option_list = option_list)

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -7,6 +7,10 @@
 library(optparse)
 library(data.table)
 library(readr)
+library(rtracklayer)
+library(tidyr)
+library(dplyr)
+library(arrow)
 
 # Process parameters -----------------------------------------------------------
 
@@ -143,9 +147,6 @@ if(opt$frombam){
     ### Idea is that featureCount's gene assignment correctly
     ### assigns the gene, so the annotation can be used to determine
     ### the set of isoforms that are legit.
-    library(rtracklayer)
-    library(tidyr)
-    library(dplyr)
 
     # Table of set of isoforms from each gene
     gene2transcript <- rtracklayer::import(opt$annotation) %>% 
@@ -449,13 +450,11 @@ if(opt$makecUP){
 
 if(opt$makeArrow){
 
-  library(arrow)
   write_parquet(muts,
                 opt$Arrowoutput)
 
 }else{
 
-  library(arrow)
   write_parquet(tibble(),
                 opt$Arrowoutput)
 

--- a/workflow/scripts/lowram/lowram_summarise.py
+++ b/workflow/scripts/lowram/lowram_summarise.py
@@ -15,7 +15,7 @@ with open(snakemake.log[0], "w") as f:
     cols_to_sum = snakemake.params.get("cols_to_sum")
     output_table = snakemake.output
     sample = snakemake.wildcards.sample
-
+    
     ### Parse cols_to_sum
 
     cols_to_sum = cols_to_sum.split(',')


### PR DESCRIPTION
Will now be able to output:

1. Counts U-content adjusted Poisson (cUP) file. Far more compressed than a cB file without sacrificing accuracy of downstream analyses in almost all cases.
2. Arrow dataset of parquet files that can be [passed to EZbakR](https://isaacvock.github.io/EZbakR/articles/EstimateFractions.html#using-the-apache-arrow-backend).