### PR TITLE
Fix unsorted fastqs path bug

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -60,7 +60,7 @@ def get_input_fastqs(wildcards):
             f"results/download_fastq/{wildcards.sample} {read}" for read in SRA_READS
         ]
         print(f"Paths: {paths}")
-        return paths
+        return sorted(paths)
 
     else:
         print("Download fastqs: No")
@@ -84,7 +84,7 @@ def get_input_fastqs(wildcards):
         # fastq_files = [f"data/fastq/{wildcards.sample}/{wildcards.sample}.{n}.fastq.gz" for n in ("1", "2")] #sorted([os.path.join(directory, f) for f in all_files if f.endswith('.fastq') or f.endswith('.fastq.gz')])
         # fastq_files = sorted(glob.glob(f"{fastq_path}/*.fastq*"))
         print(f"Found files: {fastq_files}")
-        return fastq_files
+        return sorted(fastq_files)
 
 
 # Check if fastq files are gzipped

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -59,7 +59,7 @@ def get_input_fastqs(wildcards):
         paths = [
             f"results/download_fastq/{wildcards.sample} {read}" for read in SRA_READS
         ]
-        print(f"Paths: {paths}")
+        print(f"Paths: {sorted(paths)}")
         return sorted(paths)
 
     else:
@@ -83,7 +83,7 @@ def get_input_fastqs(wildcards):
         # Filter files to only include those that end with .fastq or .fastq.gz
         # fastq_files = [f"data/fastq/{wildcards.sample}/{wildcards.sample}.{n}.fastq.gz" for n in ("1", "2")] #sorted([os.path.join(directory, f) for f in all_files if f.endswith('.fastq') or f.endswith('.fastq.gz')])
         # fastq_files = sorted(glob.glob(f"{fastq_path}/*.fastq*"))
-        print(f"Found files: {fastq_files}")
+        print(f"Found files: {sorted(fastq_files)}")
         return sorted(fastq_files)
 
 


### PR DESCRIPTION
If you don't sort fastq file names, you can effectively flip the strandedness of the library. Of course, this assumes that lexicographical sorting sorts reads by 1st and 2nd, but this is almost always the case as read 1 and 2 and denoted by "_1" and "_2"