### PR TITLE
Better filtering of incorrect isoforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
-      - isoforms
   pull_request:
     branches_ignore: []
 

--- a/.test/configs/transcript_config.yaml
+++ b/.test/configs/transcript_config.yaml
@@ -21,6 +21,9 @@ samples:
     WT_2: data/WT2
     WT_ctl: data/WTctl
 
+
+run_rsem: False
+
 ## example of what samples will look like for fastq input
 # samples:
 #   WT_1: data/fastq/WT_1

--- a/.test/configs/transcript_config.yaml
+++ b/.test/configs/transcript_config.yaml
@@ -210,7 +210,7 @@ star_index_params: "--sjdbOverhang 99"
 
 
 # SAM tags to add to alignment
-star_sam_tags: ["NH", "HI", "AS", "NM", "MD", "nM", "jI", "jM"]
+star_sam_tags: ["NH", "HI", "AS", "NM", "MD", "nM"]
 
 
 # Optional parameters to set for star align

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -213,7 +213,7 @@ final_output:
 # nonOverlap parameter to allow some leniency
 
 # Parameters for assignment of reads to genes
-fc_genes_extra: "-M"
+fc_genes_extra: "--nonOverlap 0 -M"
 
 # Parameters for assignment of reads to exons
 fc_exons_extra: "--nonOverlap 0 -M"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -50,14 +50,14 @@ def get_input_fastqs(wildcards):
     if config.get("download_fastqs", True):
         print("Download fastqs: Yes")
         if config.get("PE", False):
-            SRA_READS = ["_1.fastq", "_2.fastq"]
+            SRA_READS = ["1.fastq", "2.fastq"]
             print(f"Sample {wildcards.sample} is paired-end.")
         else:
             SRA_READS = [".fastq"]
             print(f"Sample {wildcards.sample} is single-end.")
 
         paths = [
-            f"results/download_fastq/{wildcards.sample} {read}" for read in SRA_READS
+            f"results/download_fastq/{wildcards.sample}_{read}" for read in SRA_READS
         ]
         print(f"Paths: {sorted(paths)}")
         return sorted(paths)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -276,13 +276,13 @@ args = STAR_PARAMS.split()
 # nM = Number of mismatches
 
 if config["features"]["junctions"]:
-    tags = config["star_sam_tags"]
+    tags = list(config["star_sam_tags"])
 
     if "jI" not in tags:
-        tags + ["jI"]
+        tags = tags + ["jI"]
 
     if "jM" not in tags:
-        tags + ["jM"]
+        tags = tags + ["jM"]
 
     sam_attributes = set(tags)
 

--- a/workflow/rules/features.smk
+++ b/workflow/rules/features.smk
@@ -90,20 +90,39 @@ rule featurecounts_exonbins:
         "v3.0.2/bio/subread/featurecounts"
 
 
-# Get the set of isoforms a read maps to from the transcriptome bam
-# TO-DO: No reason this can't be split up and multi-threaded
-rule read_to_transcripts:
-    input:
-        bam="results/align/{sample}-Aligned.toTranscriptome.out.bam",
-    output:
-        table=temp("results/read_to_transcripts/{sample}.csv"),
-    log:
-        "logs/read_to_transcripts/{sample}.log",
-    conda:
-        "../envs/full.yaml"
-    threads: 1
-    script:
-        "../scripts/features/transcript_assignment.py"
+if config.get("run_rsem", True):
+
+    # Get the set of isoforms a read maps to from the transcriptome bam
+    # TO-DO: No reason this can't be split up and multi-threaded
+    rule read_to_transcripts:
+        input:
+            bam="results/rsem/{sample}.transcript.bam",
+        output:
+            table=temp("results/read_to_transcripts/{sample}.csv"),
+        log:
+            "logs/read_to_transcripts/{sample}.log",
+        conda:
+            "../envs/full.yaml"
+        threads: 1
+        script:
+            "../scripts/features/transcript_assignment.py"
+
+else:
+
+    # Get the set of isoforms a read maps to from the transcriptome bam
+    # TO-DO: No reason this can't be split up and multi-threaded
+    rule read_to_transcripts:
+        input:
+            bam="results/align/{sample}-Aligned.toTranscriptome.out.bam",
+        output:
+            table=temp("results/read_to_transcripts/{sample}.csv"),
+        log:
+            "logs/read_to_transcripts/{sample}.log",
+        conda:
+            "../envs/full.yaml"
+        threads: 1
+        script:
+            "../scripts/features/transcript_assignment.py"
 
 
 # Get set of junctions a read overlaps

--- a/workflow/scripts/bam2bakR/mut_call.py
+++ b/workflow/scripts/bam2bakR/mut_call.py
@@ -27,8 +27,8 @@ parser.add_argument('--mutType', default='TC', type=str,
                     help='Type of mutation to record (default: TC)')
 parser.add_argument('--reads', default='PE', type=str, choices=['PE', 'SE'],
                     help='Type of mutation to record (default: PE)')
-parser.add_argument('--minDist', default=5, type=int, metavar = '<int>',
-                    help='Base distance from read-end filter (default: 5)')
+parser.add_argument('--minDist', default=-1, type=int, metavar = '<int>',
+                    help='Base distance from read-end filter (default: -1)')
 parser.add_argument('--minQual', default=40, type=int, metavar = '<int>',
                     help='Base minimal quality filter (default: 40)')
 parser.add_argument('--tracks', action='store_true', # Automatically stored as default = FALSE

--- a/workflow/scripts/features/transcript_assignment.py
+++ b/workflow/scripts/features/transcript_assignment.py
@@ -66,8 +66,21 @@ for r in samfile:
     # If still on the particular read
     elif queryname == r.query_name:
 
-        # Add transcript to set of transcripts
-        transcripts.add(str(r.reference_name))
+        # Check to see if RSEM bam file is provided
+        # and thus if probability of assignment
+        # can be used
+        if not r.has_tag("ZW"):
+
+            if r.get_tag("ZW") != 0:
+
+                # Add transcript to set of transcripts
+                transcripts.add(str(r.reference_name))
+
+
+        else:
+
+            # Add transcript to set of transcripts
+            transcripts.add(str(r.reference_name))
 
     # If on to the next read
     else:

--- a/workflow/scripts/features/transcript_assignment.py
+++ b/workflow/scripts/features/transcript_assignment.py
@@ -69,7 +69,7 @@ for r in samfile:
         # Check to see if RSEM bam file is provided
         # and thus if probability of assignment
         # can be used
-        if not r.has_tag("ZW"):
+        if r.has_tag("ZW"):
 
             if r.get_tag("ZW") != 0:
 


### PR DESCRIPTION
TEC assignment is currently done by parsing the transcriptome alignments output by STAR. These are a bit problematic as they ignore the strandedness of the library, meaning that isoforms on the incorrect strand can be included in the TEC. Currently, fastq2EZbakR tries to deal with this by using the gene-level assignment and an annotation. This doesn't properly handle the case of reads overlapping multiple genes when featureCounts' -O flag is set, which needs to be set to properly deal with gene fusions and the like.

Thus, this pull request uses the RSEM output transcriptome alignment instead when available. In this case, the ZW tag (probability of assignment) can be used to filter out non-existent or isoforms on the wrong strand.