### PR TITLE
Fix cnt_muts bug

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -217,10 +217,10 @@ final_output:
 # nonOverlap parameter to allow some leniency
 
 # Parameters for assignment of reads to genes
-fc_genes_extra: "--nonOverlap 0 -M"
+fc_genes_extra: "--nonOverlap 0"
 
 # Parameters for assignment of reads to exons
-fc_exons_extra: "--nonOverlap 0 -M"
+fc_exons_extra: "--nonOverlap 0"
 
 # Parameters for assignment of reads to exonbins
 fc_exonbins_extra: "-M"

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -37,7 +37,7 @@ else:
             trimmed=temp("results/trimmed/{sample}.1.fastq"),
             failed=temp("results/trimmed/{sample}.1.failed.fastq"),
             html="results/reports/{sample}.1.html",
-            json="results/reports{sample}.1.json",
+            json="results/reports/{sample}.1.json",
         log:
             "logs/fastp/{sample}.log",
         params:

--- a/workflow/scripts/bam2bakR/mut_call.sh
+++ b/workflow/scripts/bam2bakR/mut_call.sh
@@ -135,6 +135,7 @@ fi
 
 ## Need to add mutation call script to scripts!
 
+shopt -s extglob # to deal with more specific regex below
 # Call mutations
     parallel -j $cpus "python $mutcnt -b {1} \
                                               --mutType $mut_tracks \

--- a/workflow/scripts/bam2bakR/mut_call.sh
+++ b/workflow/scripts/bam2bakR/mut_call.sh
@@ -142,7 +142,7 @@ fi
 											  --SNPs "./results/snps/snp.txt" \
                                               --strandedness $strand \
                                               $( if [ "$mutpos" = "True" ]; then echo '--mutPos '; fi ) \
-                                              --reads $format" ::: ./results/counts/*_"$sample"_frag.bam \
+                                              --reads $format" ::: ./results/counts/+([0-9])_"$sample"_frag.bam \
 
 
     echo "** Mutations called for sample $sample"


### PR DESCRIPTION
Naive grep logic means that if pipeline is being run on HPC with a profile such that multiple cnt_muts jobs can be run in parallel, the wrong fragmented bam files might be grepped by a given job. Refined the regex logic to solve this.