### PR TITLE
Add option for gene-level (vs. exon-level) normalization

### DIFF
--- a/.test/configs/bam2bakR_config.yaml
+++ b/.test/configs/bam2bakR_config.yaml
@@ -129,6 +129,9 @@ mutpos: False
 # Normalize sequencing tracks?
 normalize: True
 
+# Use genes for normalization
+use_exons_only: False
+
 
 
 # Types of mutations to make tracks for otherwise

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -117,6 +117,23 @@ features:
 
 ####### PARAMETERS THAT TUNE ASPECTS OF PIPELINE BEHAVIOR, BUT WITH LIKELY REASONABLE DEFAULTS #######
 
+# What final output do you want pipeline to create?
+  # cB = standard cB file tracking number of mutations and number of mutable reference nucleotides in each read.
+  # cUP = remove the mutable reference nucleotide count and instead compute the average of this value for reads
+  #         with the same mutational content. This is orders of magnitude more compressed than a cB file (typically
+  #         around 100x smaller), and is still compatible with EZbakR. Downside is the slight information loss that
+  #         this compression leads to.
+  # arrow = Partitioned database of parquet files, in the format necessary to pass to EZbakR.
+  # 
+  # At least one of these should be set to True.
+  # If lowRAM == False, any combination of these can be set to True (including all True).
+  # If lowRAM == True, cB and cUP can not both be true.
+final_output:
+  cB: True
+  cUP: False
+  arrow: False
+
+
 # Types of mutations to make tracks for otherwise
   # Comma separated string of mutation type
   # Examples:
@@ -127,15 +144,21 @@ features:
 mut_tracks: "TC"
 
 
+### Track normalization parameters
+
 # Normalize sequencing tracks?
 normalize: True
-
 
 # String common to spike-in gene_ids in annotation gtf
   # If you have no spike-ins, then this should be "\"\"", i.e., an empty string ("")
   # Used for normalization of tracks. Thus, only relevant if normalize == True
 spikename: "\"\""
 
+# Only use exonic reads for normalization? If not, then all reads mapping to annotated genes will be used
+use_exons_only: True
+
+
+### Miscellaneous parameters
 
 # Skip adapter trimming? 
   # If True, will skip fastp step
@@ -176,22 +199,6 @@ make_tracks: True
   # provided as input
 run_rsem: True
 
-
-# What final output do you want pipeline to create?
-  # cB = standard cB file tracking number of mutations and number of mutable reference nucleotides in each read.
-  # cUP = remove the mutable reference nucleotide count and instead compute the average of this value for reads
-  #         with the same mutational content. This is orders of magnitude more compressed than a cB file (typically
-  #         around 100x smaller), and is still compatible with EZbakR. Downside is the slight information loss that
-  #         this compression leads to.
-  # arrow = Partitioned database of parquet files, in the format necessary to pass to EZbakR.
-  # 
-  # At least one of these should be set to True.
-  # If lowRAM == False, any combination of these can be set to True (including all True).
-  # If lowRAM == True, cB and cUP can not both be true.
-final_output:
-  cB: True
-  cUP: False
-  arrow: False
 
 
 ####### OPTIONAL PARAMETERS FOR THE VARIOUS TOOLS AND SCRIPTS USED #######

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -89,9 +89,7 @@ if NORMALIZE:
 
     rule normalize:
         input:
-            expand(
-                "results/featurecounts_exons/{sample}.featureCounts", sample=SAMP_NAMES
-            ),
+            NORMALIZATION_INPUT,
         output:
             "results/normalization/scale",
         log:

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -98,12 +98,13 @@ if NORMALIZE:
         params:
             rscript=workflow.source_path("../scripts/bam2bakR/normalize.R"),
             spikename=config["spikename"],
+            extra=NORMALIZATION_EXTRA,
         conda:
             "../envs/full.yaml"
         shell:
             r"""
             chmod +x {params.rscript}
-            {params.rscript} --dirs ./results/featurecounts_exons/ --output {output} --spikename {params.spikename} 1> {log} 2>&1
+            {params.rscript} {extra} --output {output} --spikename {params.spikename} 1> {log} 2>&1
             """
 
 else:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -435,6 +435,19 @@ def get_pold(wildcards):
     return config["polds"][wildcards.sample]
 
 
+### TRACK NORMALIZATION HELPERS
+
+# What is input for normalization?
+if config.get("use_exons_only", True):
+
+    NORMALIZATION_INPUT = expand("results/featurecounts_exons/{sample}.featureCounts", sample=SAMP_NAMES)
+
+else:
+
+    NORMALIZATION_INPUT = expand("results/featurecounts_genes/{sample}.featureCounts", sample=SAMP_NAMES)
+ 
+
+
 ### FEATURECOUNTS HELPERS
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -57,7 +57,7 @@ def get_input_fastqs(wildcards):
             print(f"Sample {wildcards.sample} is single-end.")
 
         paths = [
-            f"results/download_fastq/{wildcards.sample}{read}" for read in SRA_READS
+            f"results/download_fastq/{wildcards.sample} {read}" for read in SRA_READS
         ]
         print(f"Paths: {sorted(paths)}")
         return sorted(paths)
@@ -439,13 +439,14 @@ def get_pold(wildcards):
 
 # What is input for normalization?
 if config.get("use_exons_only", True):
-
-    NORMALIZATION_INPUT = expand("results/featurecounts_exons/{sample}.featureCounts", sample=SAMP_NAMES)
+    NORMALIZATION_INPUT = expand(
+        "results/featurecounts_exons/{sample}.featureCounts", sample=SAMP_NAMES
+    )
 
 else:
-
-    NORMALIZATION_INPUT = expand("results/featurecounts_genes/{sample}.featureCounts", sample=SAMP_NAMES)
- 
+    NORMALIZATION_INPUT = expand(
+        "results/featurecounts_genes/{sample}.featureCounts", sample=SAMP_NAMES
+    )
 
 
 ### FEATURECOUNTS HELPERS
@@ -908,10 +909,6 @@ MULTIQC_INPUT = expand(
 )
 
 if config.get("aligner") == "star":
-
     MULTIQC_INPUT.append(
-        expand(
-            "results/align/{sample}-Log.final.out",
-            sample=SAMP_NAMES
-        )
+        expand("results/align/{sample}-Log.final.out", sample=SAMP_NAMES)
     )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -448,6 +448,13 @@ else:
         "results/featurecounts_genes/{sample}.featureCounts", sample=SAMP_NAMES
     )
 
+# Are exons being used?
+if config.get("use_exons_only", True):
+    NORMALIZATION_EXTRA = "--use_exons_only"
+
+else:
+    NORMALIZATION_EXTRA = ""
+
 
 ### FEATURECOUNTS HELPERS
 

--- a/workflow/rules/multiQC.smk
+++ b/workflow/rules/multiQC.smk
@@ -5,10 +5,10 @@ rule multiqc:
     output:
         "results/multiqc/multiqc_report.html",
     params:
-        extra=config.get("multiqc_extra", "")
+        extra=config.get("multiqc_extra", ""),
     log:
         "logs/multiqc/multiqc.log",
     conda:
-        "../envs/multiqc.yaml",
+        "../envs/multiqc.yaml"
     script:
         "../scripts/multiQC.py"

--- a/workflow/scripts/bam2bakR/normalize.R
+++ b/workflow/scripts/bam2bakR/normalize.R
@@ -26,6 +26,11 @@ args = commandArgs(trailingOnly = TRUE)
                     help = 'File to output scale factors to'),
         make_option(c("-e", "--echocode", type="logical"),
                      default = "FALSE",
+                     help = 'print R code to stdout'),
+        make_option(c("--use_exon_only"),
+                     action = "store_false",
+                     default = TRUE,
+                     dest= "exon",
                      help = 'print R code to stdout'))
 
     opt_parser <- OptionParser(option_list = option_list)
@@ -56,7 +61,11 @@ master <- tibble()
 
 
 # Screw it, going to hardcode directory cause I can
-dirs <- paste0(getwd(), "/results/featurecounts_exons/")
+if(opt$exon){
+    dirs <- paste0(getwd(), "/results/featurecounts_exons/")
+}else{
+    dirs <- paste0(getwd(), "/results/featurecounts_genes/")
+}
 
 # Currently will not work alone due to fact that CORE files also have .featureCounts
 samplefiles <- list.files(path = dirs,

--- a/workflow/scripts/bam2bakR/normalize.R
+++ b/workflow/scripts/bam2bakR/normalize.R
@@ -27,7 +27,7 @@ args = commandArgs(trailingOnly = TRUE)
         make_option(c("-e", "--echocode", type="logical"),
                      default = "FALSE",
                      help = 'print R code to stdout'),
-        make_option(c("--use_exon_only"),
+        make_option(c("--use_exons_only"),
                      action = "store_false",
                      default = TRUE,
                      dest= "exon",


### PR DESCRIPTION
Previously, normalization of sequencing tracks could only be done based on exonic read counts. Added a new config parameter that allows users to instead use all gene-mapping reads (exons or introns) for normalization. The parameter is `use_exons_only` in the config, set to True by default.