### PR TITLE
Implement RAM-efficient (and fast(er)) joins with DuckDB

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -144,6 +144,10 @@ final_output:
 mut_tracks: "TC"
 
 
+# How much memory can the merge features and muts step use?
+max_merge_mem: "8G"
+
+
 ### Track normalization parameters
 
 # Normalize sequencing tracks?
@@ -178,11 +182,6 @@ minqual: 40
 # Are you using the Windows subsystem for Linux?
   # Due to a bug in STAR/GNU parallel, tracks have to be created iteratively if this is the case
 WSL: False
-
-
-# Merge mutation counts and feature assignments in a RAM-efficient manner?
-  # Downside is that it's a bit slower
-lowRAM: False
 
 
 # Track site-specific mutational content?

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -13,6 +13,7 @@ configfile: "config/config.yaml"
 
 ##### Impute potentially missing config parameters for backwards compatibiltiy #####
 
+# Dumb way to do this, need to refactor to just use config.get() everywhere
 if "lowRAM" not in config:
     config["lowRAM"] = False
 

--- a/workflow/envs/merge.yaml
+++ b/workflow/envs/merge.yaml
@@ -1,0 +1,11 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - r-base
+  - r-optparse
+  - r-dplyr=1.1.4
+  - r-duckdb=1.3.2
+  - r-dbi=1.2.3
+  - r-glue=1.8.0

--- a/workflow/envs/multiqc.yaml
+++ b/workflow/envs/multiqc.yaml
@@ -1,7 +1,9 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - default
+channel_priority: strict
 dependencies:
-  - multiqc=1.16
-  - python<3.12
+  - multiqc =1.30
+  - snakemake-wrapper-utils =0.7.2
+  - setuptools

--- a/workflow/envs/multiqc.yaml
+++ b/workflow/envs/multiqc.yaml
@@ -1,8 +1,7 @@
 channels:
-  - conda-forge
   - bioconda
-  - nodefaults
+  - conda-forge
+  - default
 dependencies:
-  - multiqc=1.27
-  - snakemake-wrapper-utils=0.6.2
-  - python<=3.11.3
+  - multiqc=1.16
+  - python<3.12

--- a/workflow/envs/normalize.yaml
+++ b/workflow/envs/normalize.yaml
@@ -1,0 +1,13 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - r-base
+  - r-optparse =1.7.3
+  - r-dplyr
+  - r-readr
+  - r-tidyr
+  - r-data.table
+  - r-mass =7.3.58.1
+  - bioconductor-edger =3.36.0

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -235,7 +235,7 @@ if not config["lowRAM"]:
             makeArrow=config["final_output"]["arrow"],
         log:
             "logs/merge_features_and_muts/{sample}.log",
-        threads: 8
+        threads: 32
         conda:
             "../envs/merge.yaml"
         shell:

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -215,6 +215,7 @@ if not config["lowRAM"]:
             cBout=temp("results/merge_features_and_muts/{sample}_cB.csv"),
             cUPout=temp("results/merge_features_and_muts/{sample}_cUP.csv"),
             Arrowout="results/arrow_dataset/sample={sample}/part-0.parquet",
+            duckdb = "duckdb/{sample}.duckdb",
         params:
             genes_included=config["features"]["genes"],
             exons_included=config["features"]["exons"],
@@ -236,7 +237,7 @@ if not config["lowRAM"]:
             "logs/merge_features_and_muts/{sample}.log",
         threads: 8
         conda:
-            "../envs/full.yaml"
+            "../envs/merge.yaml"
         shell:
             """
             chmod +x {params.rscript}

--- a/workflow/rules/bam2bakr.smk
+++ b/workflow/rules/bam2bakr.smk
@@ -233,6 +233,7 @@ if not config["lowRAM"]:
             makecB=config["final_output"]["cB"],
             makecUP=config["final_output"]["cUP"],
             makeArrow=config["final_output"]["arrow"],
+            MaxMem=config.get("max_merge_mem", "8G"),
         log:
             "logs/merge_features_and_muts/{sample}.log",
         threads: 32
@@ -247,7 +248,7 @@ if not config["lowRAM"]:
             -j {params.eej_included} --starjunc {params.starjunc_included} --eij {params.eij_included} \
             --annotation {params.annotation} -c {output.cBout} -m {params.muttypes} \
             --makecB {params.makecB} --makecUP {params.makecUP} --makeArrow {params.makeArrow} \
-            --cUPout {output.cUPout} --Arrowout {output.Arrowout} 1> {log} 2>&1
+            --cUPout {output.cUPout} --Arrowout {output.Arrowout} --MaxMem {params.MaxMem} 1> {log} 2>&1
             """
 
 

--- a/workflow/rules/features.smk
+++ b/workflow/rules/features.smk
@@ -20,7 +20,7 @@ rule featurecounts_genes:
     log:
         "logs/featurecounts_genes/{sample}.log",
     wrapper:
-        "v3.0.2/bio/subread/featurecounts"
+        "v7.2.0/bio/subread/featurecounts"
 
 
 # Assign reads to exons
@@ -43,7 +43,7 @@ rule featurecounts_exons:
     log:
         "logs/featurecounts_exons/{sample}.log",
     wrapper:
-        "v3.0.2/bio/subread/featurecounts"
+        "v7.2.0/bio/subread/featurecounts"
 
 
 # Assign reads to transcripts
@@ -65,7 +65,7 @@ rule featurecounts_transcripts:
     log:
         "logs/featurecounts_transcripts/{sample}.log",
     wrapper:
-        "v3.0.2/bio/subread/featurecounts"
+        "v7.2.0/bio/subread/featurecounts"
 
 
 # Assign reads to exonic bins
@@ -87,7 +87,7 @@ rule featurecounts_exonbins:
     log:
         "logs/featurecounts_exonbins/{sample}.log",
     wrapper:
-        "v3.0.2/bio/subread/featurecounts"
+        "v7.2.0/bio/subread/featurecounts"
 
 
 if config.get("run_rsem", True):
@@ -189,7 +189,7 @@ rule featurecounts_eej:
     log:
         "logs/featurecounts_eej/{sample}.log",
     wrapper:
-        "v3.0.2/bio/subread/featurecounts"
+        "v7.2.0/bio/subread/featurecounts"
 
 
 rule featurecounts_eij:
@@ -210,4 +210,4 @@ rule featurecounts_eij:
     log:
         "logs/featurecounts_eij/{sample}.log",
     wrapper:
-        "v3.0.2/bio/subread/featurecounts"
+        "v7.2.0/bio/subread/featurecounts"

--- a/workflow/rules/multiQC.smk
+++ b/workflow/rules/multiQC.smk
@@ -1,20 +1,4 @@
-# ### Compile all QC into one report
-# rule multiqc:
-#     input:
-#         MULTIQC_INPUT,
-#     output:
-#         "results/multiqc/multiqc_report.html",
-#     params:
-#         extra=config.get("multiqc_extra", ""),
-#     log:
-#         "logs/multiqc/multiqc.log",
-#     conda:
-#         "../envs/multiqc.yaml"
-#     script:
-#         "../scripts/multiQC.py"
-
-
-### StackOverflow solution
+### Compile all QC into one report
 rule multiqc:
     input:
         MULTIQC_INPUT,
@@ -22,14 +6,28 @@ rule multiqc:
         "results/multiqc/multiqc_report.html",
     params:
         extra=config.get("multiqc_extra", ""),
-        output_dir=lambda wildcards, output: os.path.dirname(output[0]),
-        output_file_name=lambda wildcards, output: os.path.basename(output[0]),
-        input_directories=lambda wildcards, input: set(os.path.dirname(fp) for fp in input)
     log:
         "logs/multiqc/multiqc.log",
-    conda:
-        "../envs/multiqc.yaml"
-    shell:
-        "multiqc {params.extra} --force "
-        "-o {params.output_dir} -n {params.output_file_name} "
-        "{params.input_directories} &> {log}"
+    wrapper:
+        "v3.5.3/bio/multiqc"
+
+
+# ### StackOverflow solution
+# rule multiqc:
+#     input:
+#         MULTIQC_INPUT,
+#     output:
+#         "results/multiqc/multiqc_report.html",
+#     params:
+#         extra=config.get("multiqc_extra", ""),
+#         output_dir=lambda wildcards, output: os.path.dirname(output[0]),
+#         output_file_name=lambda wildcards, output: os.path.basename(output[0]),
+#         input_directories=lambda wildcards, input: set(os.path.dirname(fp) for fp in input)
+#     log:
+#         "logs/multiqc/multiqc.log",
+#     conda:
+#         "../envs/multiqc.yaml"
+#     shell:
+#         "multiqc {params.extra} --force "
+#         "-o {params.output_dir} -n {params.output_file_name} "
+#         "{params.input_directories} &> {log}"

--- a/workflow/rules/multiQC.smk
+++ b/workflow/rules/multiQC.smk
@@ -1,4 +1,20 @@
-### Compile all QC into one report
+# ### Compile all QC into one report
+# rule multiqc:
+#     input:
+#         MULTIQC_INPUT,
+#     output:
+#         "results/multiqc/multiqc_report.html",
+#     params:
+#         extra=config.get("multiqc_extra", ""),
+#     log:
+#         "logs/multiqc/multiqc.log",
+#     conda:
+#         "../envs/multiqc.yaml"
+#     script:
+#         "../scripts/multiQC.py"
+
+
+### StackOverflow solution
 rule multiqc:
     input:
         MULTIQC_INPUT,
@@ -6,9 +22,14 @@ rule multiqc:
         "results/multiqc/multiqc_report.html",
     params:
         extra=config.get("multiqc_extra", ""),
+        output_dir=lambda wildcards, output: os.path.dirname(output[0]),
+        output_file_name=lambda wildcards, output: os.path.basename(output[0]),
+        input_directories=lambda wildcards, input: set(os.path.dirname(fp) for fp in input)
     log:
         "logs/multiqc/multiqc.log",
     conda:
         "../envs/multiqc.yaml"
-    script:
-        "../scripts/multiQC.py"
+    shell:
+        "multiqc {params.extra} --force "
+        "-o {params.output_dir} -n {params.output_file_name} "
+        "{params.input_directories} &> {log}"

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -95,6 +95,8 @@ opt <- parse_args(opt_parser) # Load options from command line.
 #   ArrowOutput = "C:/Users/isaac/Documents/Simon_Lab/Sandbox/fastq2EZbakR/Data/sample=DMSO_8hr_1/new_cB_test.parquet"
 # )
 
+message("opt contents:\n",
+        paste(capture.output(str(opt)), collapse = "\n"))
 
 # DuckDB strategy --------------------------------------------------------------
 
@@ -136,6 +138,8 @@ feature_vect <- c()
 
 if(opt$genes){
   
+  cat("Making genes table...")
+  
   register_feat("genes", glue("./results/featurecounts_genes/{opt$sample}.s.bam.featureCounts"), "GF")
   
   feature_vect <- c(feature_vect, "GF")
@@ -144,6 +148,9 @@ if(opt$genes){
 
 
 if(opt$frombam){
+  
+  cat("Making TEC table...")
+  
   
   dbExecute(con, glue("
   CREATE OR REPLACE VIEW transcripts AS
@@ -159,6 +166,9 @@ if(opt$frombam){
 
 if(opt$exons){
   
+  cat("Making exons table...")
+  
+  
   register_feat("exons", glue("./results/featurecounts_exons/{opt$sample}.s.bam.featureCounts"), "XF")
   
   feature_vect <- c(feature_vect, "XF")
@@ -168,13 +178,19 @@ if(opt$exons){
 
 if(opt$exonbins){
   
-  register_feat("ebs", glue("results/featurecounts_exonbins/{opt$sample}.s.bam.featureCounts"), "exon_bin")
+  cat("Making exonbins table...")
+  
+  
+  register_feat("exonbins", glue("results/featurecounts_exonbins/{opt$sample}.s.bam.featureCounts"), "exon_bin")
   
   feature_vect <- c(feature_vect, "exon_bin")
   
 }
 
 if(opt$eej){
+  
+  cat("Making eej table...")
+  
   
   register_feat("eej", glue("C:/Users/isaac/Documents/Simon_Lab/Sandbox/fastq2EZbakR/Data/tables/exon_bins.tsv.gz"), "ee_junction_id")
   
@@ -184,6 +200,9 @@ if(opt$eej){
 
 if(opt$eij){
   
+  cat("Making eij table...")
+  
+  
   register_feat("eij", glue("C:/Users/isaac/Documents/Simon_Lab/Sandbox/fastq2EZbakR/Data/tables/exon_bins.tsv.gz"), "ei_junction_id")
   
   feature_vect <- c(feature_vect, "ei_junction_id")
@@ -192,6 +211,9 @@ if(opt$eij){
 
 
 if(opt$starjunc){
+  
+  cat("Making junctions table...")
+  
   
   dbExecute(con, glue("
   CREATE OR REPLACE VIEW starjunc AS
@@ -252,7 +274,7 @@ select_fragments <- c("m.*")   # always start with all mutation columns
 join_fragments   <- character()
 
 for (feat in feat_catalogue) {
-  if (isTRUE(opt[[feat$flag]])) {
+  if (opt[[feat$flag]]) {
     select_fragments <- c(select_fragments, feat$select)
     join_fragments   <- c(join_fragments,   feat$join)
   }

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -281,22 +281,20 @@ base_cols <- paste0('n', substr(mut_cols, 1, 1))
 feature_cols <- feature_vect
 
 
-if(opt$makecB | opt$makeArrow){
-  
-  # Create summarized cB
-  dbExecute(con, glue("
-  CREATE OR REPLACE TABLE cB AS
-    SELECT 'opt$sample'      AS sample,
-           rname, sj, {paste(feature_cols, collapse = ',')},
-           {paste(mut_cols, collapse = ',')},
-           {paste(base_cols, collapse = ',')},
-           COUNT(*)            AS n
-    FROM   merged
-    GROUP  BY ALL;
-  "))
-  
-}
+cat(opt$makecB)
+cat(opt$makeArrow)
 
+# Create summarized cB
+dbExecute(con, glue("
+CREATE OR REPLACE TABLE cB AS
+  SELECT 'opt$sample'      AS sample,
+          rname, sj, {paste(feature_cols, collapse = ',')},
+          {paste(mut_cols, collapse = ',')},
+          {paste(base_cols, collapse = ',')},
+          COUNT(*)            AS n
+  FROM   merged
+  GROUP  BY ALL;
+"))
 
 #### Write to cB ####
 

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -192,7 +192,7 @@ if(opt$eej){
   cat("Making eej table...")
   
   
-  register_feat("eej", glue("C:/Users/isaac/Documents/Simon_Lab/Sandbox/fastq2EZbakR/Data/tables/exon_bins.tsv.gz"), "ee_junction_id")
+  register_feat("eej", glue("results/featurecounts_eej/{opt$sample}.s.bam.featureCounts"), "ee_junction_id")
   
   feature_vect <- c(feature_vect, "ee_junction_id")
   
@@ -203,7 +203,7 @@ if(opt$eij){
   cat("Making eij table...")
   
   
-  register_feat("eij", glue("C:/Users/isaac/Documents/Simon_Lab/Sandbox/fastq2EZbakR/Data/tables/exon_bins.tsv.gz"), "ei_junction_id")
+  register_feat("eij", glue("results/featurecounts_eij/{opt$sample}.s.bam.featureCounts"), "ei_junction_id")
   
   feature_vect <- c(feature_vect, "ei_junction_id")
   

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -297,6 +297,12 @@ cat(sql)
 dbExecute(con, sql)
 
 
+# Write to csv
+dbExecute(con, glue("
+  COPY merged TO '{opt$output}' (FORMAT CSV, HEADER 1);
+"))
+
+
 #### cB table creation ####
 mut_cols  <- strsplit(opt$muttypes, ",")[[1]]
 base_cols <- paste0('n', substr(mut_cols, 1, 1))
@@ -326,7 +332,7 @@ if(opt$makecB){
     
   # Write to csv
   dbExecute(con, glue("
-    COPY cB TO '{opt$cBoutput}' (FORMAT CSV, HEADER 1);
+    COPY cB TO '{opt$cBoutput}' (FORMAT CSV, HEADER);
   "))
   
     
@@ -346,7 +352,7 @@ if(opt$makeArrow){
   
   # 2b → Parquet
   dbExecute(con, glue("
-    COPY cB TO '{opt$Arrowoutput}' (FORMAT PARQUET);
+    COPY cB TO '{opt$Arrowoutput}' (FORMAT PARQUET, COMPRESSION snappy);
   "))
   
   
@@ -377,10 +383,14 @@ if(opt$makecUP){
   
   # Create summarized cUP
   dbExecute(con, glue("
-    CREATE OR REPLACE TABLE cB AS
+    CREATE OR REPLACE TABLE cUP AS
     SELECT {select_clause}
     FROM   merged
     GROUP  BY {group_by_clause};
+  "))
+
+  dbExecute(con, glue("
+    COPY cUP TO '{opt$cUPoutput}' (FORMAT CSV, HEADER);
   "))
   
 }else{

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -264,7 +264,7 @@ feat_catalogue <- list(
   ),
   eij = list(
     flag   = "eij",                                
-    select = "COALESCE(t.ei_junction_id, '__no_feature') AS ei_junction_id",
+    select = "COALESCE(eij.ei_junction_id, '__no_feature') AS ei_junction_id",
     join   = "LEFT JOIN eij   eij  USING (qname)"
   )
 )

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -342,11 +342,11 @@ if(opt$makecB){
 
 if(opt$makeArrow){
   
-  dir.create(dirname(opt$ArrowOutput), showWarnings = FALSE)
+  dir.create(dirname(opt$Arrowoutput), showWarnings = FALSE)
   
   # 2b → Parquet
   dbExecute(con, glue("
-    COPY cB TO '{opt$ArrowOutput}' (FORMAT PARQUET);
+    COPY cB TO '{opt$Arrowoutput}' (FORMAT PARQUET);
   "))
   
   

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -257,12 +257,12 @@ feat_catalogue <- list(
               COALESCE(sj.junction_end,   '__no_feature') AS junction_end",
     join   = "LEFT JOIN starjunc      sj USING (qname)"
   ),
-  transcripts = list(
+  eej = list(
     flag   = "eej",                                
     select = "COALESCE(eej.ee_junction_id, '__no_feature') AS ee_junction_id",
     join   = "LEFT JOIN eej   eej  USING (qname)"
   ),
-  transcripts = list(
+  eij = list(
     flag   = "eij",                                
     select = "COALESCE(t.ei_junction_id, '__no_feature') AS ei_junction_id",
     join   = "LEFT JOIN eij   eij  USING (qname)"

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -315,7 +315,7 @@ cat(opt$makeArrow)
 # Create summarized cB
 dbExecute(con, glue("
 CREATE OR REPLACE TABLE cB AS
-  SELECT 'opt$sample'      AS sample,
+  SELECT '{opt$sample}'      AS sample,
           rname, sj, {paste(feature_cols, collapse = ',')},
           {paste(mut_cols, collapse = ',')},
           {paste(base_cols, collapse = ',')},


### PR DESCRIPTION
Completely refactored the merge_features_and_muts step so as to use DuckDB instead of data.table to keep RAM usage under wraps and (hopefully) roughly constant for all samples rather than scaling with the sequencing depth. Also updated the featureCounts wrapper in hopes that the developers are [true to their word](https://support.bioconductor.org/p/9156185/) and implemented sorting of CORE file feature assignment output.

[EDIT]: Tested on massive real dataset, it does in fact keep RAM usage under wraps and is actually faster than my sequential data.table joins approach! Seems like featureCounts sorting bug is still an issue though. Not a huge deal though as TEC assignment doesn't use featureCounts and exon bins should be split anyway.