### PR TITLE
Small optimizations to single-nucleotide analyses

### DIFF
--- a/.test/configs/mutpos_config.yaml
+++ b/.test/configs/mutpos_config.yaml
@@ -95,8 +95,8 @@ strategies:
 
 # Features to quantify
 features:
-    genes: True
-    exons: True
+    genes: False
+    exons: False
     transcripts: False
     exonic_bins: False
     junctions: False

--- a/workflow/envs/full.yaml
+++ b/workflow/envs/full.yaml
@@ -10,7 +10,7 @@ dependencies:
   - parallel =20210222
   - pigz =2.8
   - pysam=0.23.3
-  - star =2.7.10b
+  - star =2.7.11b
   - bcftools = 1.22
   - igvtools =2.5.3
   - natsort=8.4.0

--- a/workflow/envs/full.yaml
+++ b/workflow/envs/full.yaml
@@ -10,7 +10,7 @@ dependencies:
   - parallel =20210222
   - pigz =2.8
   - pysam=0.23.3
-  - star =2.7.11b
+  - star =2.7.10b
   - bcftools = 1.22
   - igvtools =2.5.3
   - natsort=8.4.0

--- a/workflow/envs/star.yaml
+++ b/workflow/envs/star.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - star =2.7.11b
+  - star =2.7.10b

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -326,16 +326,34 @@ cat(opt$makecB)
 cat(opt$makeArrow)
 
 # Create summarized cB
-dbExecute(con, glue("
-CREATE OR REPLACE TABLE cB AS
-  SELECT '{opt$sample}'      AS sample,
-          rname, sj, {paste(feature_cols, collapse = ',')},
-          {paste(mut_cols, collapse = ',')},
-          {paste(base_cols, collapse = ',')},
-          COUNT(*)            AS n
-  FROM   merged
-  GROUP  BY ALL;
-"))
+if(length(join_fragments) == 0){
+
+  dbExecute(con, glue("
+  CREATE OR REPLACE TABLE cB AS
+    SELECT '{opt$sample}'      AS sample,
+            rname, sj,
+            {paste(mut_cols, collapse = ',')},
+            {paste(base_cols, collapse = ',')},
+            COUNT(*)            AS n
+    FROM   merged
+    GROUP  BY ALL;
+  "))
+
+}else{
+
+  dbExecute(con, glue("
+  CREATE OR REPLACE TABLE cB AS
+    SELECT '{opt$sample}'      AS sample,
+            rname, sj, {paste(feature_cols, collapse = ',')},
+            {paste(mut_cols, collapse = ',')},
+            {paste(base_cols, collapse = ',')},
+            COUNT(*)            AS n
+    FROM   merged
+    GROUP  BY ALL;
+  "))
+
+}
+
 
 #### Write to cB ####
 

--- a/workflow/scripts/bam2bakR/merge_features_and_muts.R
+++ b/workflow/scripts/bam2bakR/merge_features_and_muts.R
@@ -284,12 +284,25 @@ for (feat in feat_catalogue) {
 
 #### LEFT JOIN ####
 
-sql <- glue("
-  CREATE OR REPLACE TABLE merged AS
-  SELECT {paste(select_fragments, collapse = ',\n         ')}
-  FROM   muts m
-  {paste(join_fragments, collapse = '\n  ')}
-;")
+if(length(join_fragments) == 0){
+
+  sql <- glue("
+    CREATE OR REPLACE TABLE merged AS
+    SELECT {paste(select_fragments, collapse = ',\n         ')}
+    FROM   muts m
+  ;")
+
+}else{
+
+  sql <- glue("
+    CREATE OR REPLACE TABLE merged AS
+    SELECT {paste(select_fragments, collapse = ',\n         ')}
+    FROM   muts m
+    {paste(join_fragments, collapse = '\n  ')}
+  ;")
+}
+
+
 
 # Print for debugging
 cat(sql)

--- a/workflow/scripts/bam2bakR/mut_call.sh
+++ b/workflow/scripts/bam2bakR/mut_call.sh
@@ -118,7 +118,7 @@ fi
     # disk space and RAM usage when running the mutation counting script.
 if [ "$mutpos" = "True" ]; then
 
-    samtools sort -@ "$cpus" "$input" | samtools sort -n -@ "$cpus" - | samtools view - \
+    samtools sort --template-coordinate -@ "$cpus" "$input" | samtools view - \
     	| awk \
     		-v fragment_size="$newFragmentSize" \
     		-v sample="$sample" \


### PR DESCRIPTION
Following changes:

1. Using template-coordinate sorting to reduce disk space usage when setting `mutpos: True`. 
2. Fix bug in merge_features_and_muts when no features are set to True.
3. Small version change in environment to make bam2bakR fully ARM64 compatible (alignment with STAR will not be though).