### PR TITLE
Avoid occasional crash at track creation step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,43 +47,43 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/altoutput_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --latency-wait 30"
+        args: "--configfile .test/configs/altoutput_config.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --latency-wait 30"
     - name: Test workflow (transcripts no fastp)
       uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/transcript_nofastp.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --latency-wait 30"
+        args: "--configfile .test/configs/transcript_nofastp.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --latency-wait 30"
     - name: Test workflow (mutpos)
       uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/mutpos_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --latency-wait 30"
+        args: "--configfile .test/configs/mutpos_config.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --latency-wait 30"
     - name: Test workflow (transcripts)
       uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/transcript_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --latency-wait 30"
+        args: "--configfile .test/configs/transcript_config.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --latency-wait 30"
     - name: Test workflow (bam2EZbakR)
       uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/bam2bakR_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --latency-wait 30"
+        args: "--configfile .test/configs/bam2bakR_config.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --latency-wait 30"
     - name: Test workflow (hisat2)
       uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/hisat2_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --latency-wait 30"
+        args: "--configfile .test/configs/hisat2_config.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --latency-wait 30"
     - name: Clean up
       uses: ezherman/snakemake-github-action@b6bd319468ad9a049d37058554ebcd52eca38c92
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/transcript_nofastp.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --delete-all-output --latency-wait 30"
+        args: "--configfile .test/configs/transcript_nofastp.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --delete-all-output --latency-wait 30"
 
   run-workflow-3p:
     runs-on: ubuntu-latest
@@ -99,4 +99,4 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        args: "--configfile .test/configs/threeputr_config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --latency-wait 30"
+        args: "--configfile .test/configs/threeputr_config.yaml --use-conda --show-failed-logs --cores 2 --set-threads maketdf=1 --conda-cleanup-pkgs cache --latency-wait 30"


### PR DESCRIPTION
Tests can occasionally crash at track creation step due to too many Java VM's being spun up. This changes the tests to hopefully avoid that problem.