### PR TITLE
Chrluh add .bed

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -71,6 +71,15 @@ annotation: data/annotation/genome.gtf
     # 2) hisat2
 aligner: "star"
 
+# Modify output .bam to remove read sets? (e.g. mito reads, PolIII, etc)
+  # Options are:
+    # 1) yes
+    # 2) no
+modify_bam: "no"
+
+# Only relevant if modify_bam is "yes"
+# Reads overlapping intervals in this BED file are dropped from the output BAM
+path_to_removal_bed: data/annotation/removal.bed
 
 # Path to directory containing indices
   # Indices will be built automatically if not present

--- a/workflow/rules/alignment.smk
+++ b/workflow/rules/alignment.smk
@@ -55,7 +55,7 @@ if config["aligner"] == "star":
                 fq2=get_fastq_r2,
                 index=config["indices"],
             output:
-                aln="results/align/{sample}.bam",
+                aln="results/alfullbam/{sample}.bam",
                 sj="results/align/{sample}-SJ.out.tab",
                 log="results/align/{sample}-Log.out",
                 log_progress="results/align/{sample}-Log.progress.out",
@@ -84,7 +84,7 @@ if config["aligner"] == "star":
                 fq1=get_fastq_r1,
                 index=config["indices"],
             output:
-                aln="results/align/{sample}.bam",
+                aln="results/alfullbam/{sample}.bam",
                 sj="results/align/{sample}-SJ.out.tab",
                 log="results/align/{sample}-Log.out",
                 log_progress="results/align/{sample}-Log.progress.out",
@@ -105,6 +105,40 @@ if config["aligner"] == "star":
             threads: 24
             script:
                 "../scripts/alignment/star-align.py"
+
+
+######################################################################################
+##### REMOVE READ SETS FROM MAIN .bam OUTPUT
+######################################################################################
+
+
+if config.get("modify_bam", "no") == "no":
+
+    rule rename_file:
+        input:
+            "results/alfullbam/{sample}.bam",
+        output:
+            "results/align/{sample}.bam",
+        shell:
+            "mv {input} {output}"
+
+
+if config.get("modify_bam", "no") == "yes":
+
+    rule modify_bam:
+        input:
+            bam="results/alfullbam/{sample}.bam",
+            bed=config["path_to_removal_bed"],
+        output:
+            bam="results/align/{sample}.bam",
+        log:
+            "logs/align/{sample}_modifybam.log",
+        conda:
+            "../envs/full.yaml"
+        shell:
+            """
+            samtools view -h -L {input.bed} -U {output.bam} {input.bam} > /dev/null 2> {log}
+            """
 
 
 ######################################################################################
@@ -192,7 +226,7 @@ if config["aligner"] == "hisat2":
             reads=get_hisat2_reads,
             idx=config["indices"],
         output:
-            "results/align/{sample}.bam",
+            "results/alfullbam/{sample}.bam",
         log:
             "logs/align/{sample}_hisat2.log",
         params:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -9,6 +9,9 @@ config["bam2bakr"] = all(value.endswith(".bam") for value in config["samples"].v
 if config["features"]["junctions"]:
     config["remove_tags"] = False
 
+### Safety measure, that if modify_bam is not in the config.yaml (e.g. in old config files before this change), that it is set to no as a standard.
+if “modify_bam” not in config:
+    config[“modify_bam”] = “no”
 
 ### GENERAL HELPER FUNCTIONS/VARIABLES USED IN ALL CASES
 


### PR DESCRIPTION
We added a feature to remove gene sets from the .bam file, according to https://github.com/mtcouvi/fastq2EZbakR.git.
This feature is present in the mentioned fork and with this implementation now also present with the most recent version of fastq2EzbakR.